### PR TITLE
Implement deployment CLI and Docker setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+DATABASE_URL=sqlite:///mud.db
+PORT=5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-FROM python:3.10
+FROM python:3.11-slim
 
-# Set the working directory inside the container
-WORKDIR /app/mud
+WORKDIR /app
 
-# Copy only the project files
-COPY mud/pyproject.toml ./
-COPY mud ./
+COPY mud/pyproject.toml ./pyproject.toml
+RUN pip install poetry && poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi
 
-# Install dependencies with Poetry
-RUN pip install poetry && \
-    poetry config virtualenvs.create false && \
-    poetry install --no-interaction --no-ansi
+COPY . .
 
-CMD ["python", "mud.py"]
+CMD ["mud", "runserver"]

--- a/TODO.md
+++ b/TODO.md
@@ -1832,9 +1832,9 @@ Call this after every `perform_action()` in agent loop.
 
 ### 🛠️ Next Step
 
-- Step 14 will address **Deployment, CLI Wrappers, and Dockerization**, to prepare the project for production and developer onboarding.
+- ✅ Step 14 addressed **Deployment, CLI Wrappers, and Dockerization**, preparing the project for production and developer onboarding.
 
-## 🚀 Step 14: Deployment, CLI Tools, and Dockerization
+## ✅ Step 14: Deployment, CLI Tools, and Dockerization
 
 **Objective**: Finalize the project for real-world use by wrapping it with CLI tools, `.env`-based config, and Docker support. This enables easy server bootstrapping, environment separation, and deployment consistency.
 
@@ -2028,7 +2028,7 @@ You have now fully migrated a C-based MUD engine with text and `.h`-based data i
 
 ---
 
-## 🌐 Step 15 Addendum: Telnet Access via Docker + Test Character Loader
+## ✅ Step 15 Addendum: Telnet Access via Docker + Test Character Loader
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
-version: "3"
+version: "3.8"
 services:
-  app:
-    image: avinson/rom
-    volumes:
-      - ./log:/opt/rom/log:rw
-      - ./player:/opt/rom/player:rw
+  mud:
+    build: .
     ports:
-      - 4000:4000
+      - "${PORT:-5000}:5000"
+    env_file:
+      - .env
+    volumes:
+      - .:/app
+    command: poetry run mud socketserver

--- a/mud/__main__.py
+++ b/mud/__main__.py
@@ -1,9 +1,30 @@
 import asyncio
 import typer
+from mud.server import run_game_loop
+from mud.db.migrations import run_migrations
 from mud.net.telnet_server import start_server as start_telnet
 from mud.network.websocket_server import run as start_websocket
 
 cli = typer.Typer()
+
+@cli.command()
+def runserver():
+    """Start the main game server."""
+    run_game_loop()
+
+
+@cli.command()
+def migrate():
+    """Run database migrations."""
+    run_migrations()
+
+
+@cli.command()
+def loadtestuser():
+    """Load a default test account and character."""
+    from mud.scripts.load_test_data import load_test_user
+    load_test_user()
+
 
 @cli.command()
 def socketserver(host: str = "0.0.0.0", port: int = 5000):

--- a/mud/config.py
+++ b/mud/config.py
@@ -1,8 +1,12 @@
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Configuration for servers
-HOST = os.environ.get("HOST", "0.0.0.0")
-PORT = int(os.environ.get("PORT", "8000"))
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///mud.db")
+PORT = int(os.getenv("PORT", 5000))
+HOST = os.getenv("HOST", "0.0.0.0")
 
 # Comma separated list of allowed CORS origins
-CORS_ORIGINS = [origin.strip() for origin in os.environ.get("CORS_ORIGINS", "*").split(",")]
+CORS_ORIGINS = [origin.strip() for origin in os.getenv("CORS_ORIGINS", "*").split(",")]

--- a/mud/db/migrations.py
+++ b/mud/db/migrations.py
@@ -1,0 +1,7 @@
+from mud.db.models import Base
+from mud.db.session import engine
+
+
+def run_migrations() -> None:
+    Base.metadata.create_all(bind=engine)
+    print("✅ Migrations complete.")

--- a/mud/pyproject.toml
+++ b/mud/pyproject.toml
@@ -8,9 +8,14 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.10"
 sqlalchemy = "^1.4"
+typer = "^0.9"
+python-dotenv = "^1.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4"
+
+[tool.poetry.scripts]
+mud = "mud.__main__:cli"
 
 
 [build-system]

--- a/mud/scripts/load_test_data.py
+++ b/mud/scripts/load_test_data.py
@@ -1,0 +1,17 @@
+from mud.db.session import SessionLocal
+from mud.db.models import PlayerAccount, Character
+from mud.world.world_state import initialize_world
+
+
+def load_test_user():
+    db = SessionLocal()
+
+    account = PlayerAccount(username="test", email="test@example.com")
+    account.set_password("test123")
+    db.add(account)
+    db.flush()
+
+    char = Character(name="Tester", hp=100, room_vnum=3001, player_id=account.id)
+    db.add(char)
+    db.commit()
+    print("✅ Test user created: login=test / pw=test123")

--- a/mud/server.py
+++ b/mud/server.py
@@ -1,0 +1,8 @@
+import asyncio
+from mud.net.telnet_server import start_server
+from mud.config import HOST, PORT
+
+
+def run_game_loop():
+    print("\U0001F30D Starting MUD server...")
+    asyncio.run(start_server(host=HOST, port=PORT))


### PR DESCRIPTION
## Summary
- load environment variables in `mud/config.py`
- create `.env` with default DB URL and port
- provide database migrations utility
- implement `run_game_loop` server wrapper
- expand CLI with `runserver`, `migrate`, and test user loader
- add Dockerfile and docker-compose for deployment
- update TODO to mark steps 14 and 15 done

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68775c7f3f7c8320a641b8896a3461ac