### PR TITLE
Fix Poetry workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,27 @@
 FROM python:3.11-slim
 
+# Build steps start in /app so we can copy the whole repository
 WORKDIR /app
 
 # Copy project metadata first for better layer caching
-COPY mud/pyproject.toml /app/mud/pyproject.toml
+COPY mud/pyproject.toml mud/pyproject.toml
 
 # Copy the mud package including a lock file if present
-COPY mud/ /app/mud/
+COPY mud/ mud/
 
-# Install Poetry and project dependencies. If no lock file is
-# present, generate one during the build.
+# Install Poetry and project dependencies. If no lock file is present,
+# generate one during the build.
 RUN pip install --no-cache-dir poetry \
-    && if [ ! -f /app/mud/poetry.lock ]; then \
-         poetry -C /app/mud lock; \
+    && if [ ! -f mud/poetry.lock ]; then \
+         poetry -C mud lock; \
        fi \
-    && poetry -C /app/mud install --no-interaction --no-ansi
+    && poetry -C mud install --no-interaction --no-ansi
 
 # Copy the rest of the repository
-COPY . /app
+COPY . .
+
+# The application expects to run from the mud directory where
+# pyproject.toml lives so Poetry can locate the project
+WORKDIR /app/mud
 
 CMD ["poetry", "run", "mud", "socketserver"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       - .env
     volumes:
       - .:/app
-      - ./mud/pyproject.toml:/app/mud/pyproject.toml
+    working_dir: /app/mud


### PR DESCRIPTION
## Summary
- set Docker's runtime directory to the mud package so Poetry can find pyproject.toml
- remove extra bind mount and set `working_dir` in docker-compose

## Testing
- `poetry -C mud run pytest ../tests -q` *(fails: FileNotFoundError for area/area.lst)*

------
https://chatgpt.com/codex/tasks/task_b_68788020e2e48320906b6559e0b0595f