### PR TITLE
ci: install project and SQLAlchemy on Python 3.13 to fix pytest import errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.13'
+          check-latest: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
           pip install -e .
-          pip install pytest mypy ruff flake8 jsonschema
       - name: Lint
         run: |
           ruff check mud/net tests/test_telnet_server.py tests/test_ansi.py
@@ -22,4 +23,4 @@ jobs:
       - name: Type check
         run: mypy mud/net/ansi.py mud/net/protocol.py mud/net/connection.py --follow-imports=skip
       - name: Test
-        run: pytest
+        run: pytest -q

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+pytest>=8.0
+mypy
+ruff
+flake8
+jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+SQLAlchemy>=2.0
+typer>=0.9
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- Install runtime and dev dependencies from new requirements files
- Run CI on Python 3.13 and install the project in editable mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bb138946ec83208921dfce97d9ef52