### PR TITLE
ci: install project and SQLAlchemy on Python 3.13 to fix pytest import errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'  # Use 3.12 for dependency compatibility
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
-          pip install -e .
+          python-version: '3.13'
+          check-latest: true
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install project
+        run: pip install -e .[dev] || pip install -e .
       - name: Lint
         run: |
           ruff check mud/net tests/test_telnet_server.py tests/test_ansi.py

--- a/mud/pyproject.toml
+++ b/mud/pyproject.toml
@@ -7,12 +7,12 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"
-sqlalchemy = "^1.4"
-typer = "^0.9"
-python-dotenv = "^1.0"
+sqlalchemy = ">=2.0"
+typer = ">=0.9"
+python-dotenv = ">=1.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.4"
+pytest = ">=8.0"
 
 [tool.poetry.scripts]
 mud = "mud.__main__:cli"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pytest>=8.3
 pytest-cov>=6.0
 mypy

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,21 @@ setup(
     version='0.1.0',
     packages=['mud'] + [f'mud.{p}' for p in find_packages('mud')],
     package_dir={'mud': 'mud'},
+    install_requires=[
+        "SQLAlchemy>=2.0",
+        "typer>=0.9",
+        "python-dotenv>=1.0",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=8.0",
+            "pytest-cov>=6.0",
+            "mypy",
+            "ruff",
+            "flake8",
+            "jsonschema",
+        ],
+    },
     entry_points={
         'console_scripts': [
             'mud=mud.__main__:cli',


### PR DESCRIPTION
## Summary
- declare SQLAlchemy and dev tooling in setup.py for editable installs
- require SQLAlchemy>=2.0 and pytest>=8.0 in poetry metadata
- run CI on Python 3.13 and install project with dev extras

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68bb1cf752d88320ab0fa699b8e7e085