### PR TITLE
Align SQLAlchemy version range

### DIFF
--- a/mud/pyproject.toml
+++ b/mud/pyproject.toml
@@ -7,7 +7,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"
-sqlalchemy = ">=2.0"
+sqlalchemy = ">=2.0,<3"
 typer = ">=0.9"
 python-dotenv = ">=1.0"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-SQLAlchemy>=2.0,<3
+sqlalchemy>=2.0,<3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=['mud'] + [f'mud.{p}' for p in find_packages('mud')],
     package_dir={'mud': 'mud'},
     install_requires=[
-        "SQLAlchemy>=2.0",
+        "SQLAlchemy>=2.0,<3",
         "typer>=0.9",
         "python-dotenv>=1.0",
     ],


### PR DESCRIPTION
## Summary
- Align SQLAlchemy dependency to `>=2.0,<3` across requirements, setup configuration, and poetry project

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bb67bad31083209c10d8d42db83602