### PR TITLE
ci: add PyPI trusted publisher workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Publish to PyPI (Trusted Publisher)
+
+on:
+  push:
+    tags:
+      - 'v*'   # e.g., v1.2.3
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write    # REQUIRED for OIDC (Trusted Publisher)
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build backend
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build distributions
+        run: python -m build  # creates dist/*.whl and dist/*.tar.gz
+
+      # Optional sanity check; doesn't upload
+      - name: Twine check (optional)
+        run: |
+          python -m pip install twine
+          twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # With Trusted Publisher configured on PyPI, no token or secrets are needed.
+        # The action will use GitHub's OIDC identity to request a short-lived token from PyPI.

--- a/README.md
+++ b/README.md
@@ -53,12 +53,18 @@ pytest
 
 ### Publishing
 
-Build and upload a wheel to PyPI when releasing:
+To release a new version to PyPI:
+
+1. Update the version in `pyproject.toml`.
+2. Commit and tag:
 
 ```bash
-python -m build
-twine upload dist/*
+git commit -am "release: v1.2.3"
+git tag v1.2.3
+git push origin main --tags
 ```
+
+The GitHub Actions workflow will build and publish the package when the tag is pushed.
 
 
 ## Python Architecture


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish releases to PyPI via Trusted Publisher
- document tag-based release process in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bb9e6608a88320967e749927d91029