### PR TITLE
parity: affects_saves — audit notes, tasks, rules (+tiny fix)

### DIFF
--- a/PYTHON_PORT_PLAN.md
+++ b/PYTHON_PORT_PLAN.md
@@ -1,4 +1,4 @@
-<!-- LAST-PROCESSED: logging_admin -->
+<!-- LAST-PROCESSED: affects_saves -->
 <!-- DO-NOT-SELECT-SECTIONS: 8,10 -->
 <!-- SUBSYSTEM-CATALOG: combat, skills_spells, affects_saves, command_interpreter, socials, channels, wiznet_imm,
 world_loader, resets, weather, time_daynight, movement_encumbrance, stats_position, shops_economy, boards_notes,
@@ -45,17 +45,19 @@ This document outlines the steps needed to port the remaining ROM 2.4 QuickMUD C
 <!-- AUDITED: affects_saves, socials, wiznet_imm, time_daynight, movement_encumbrance, help_system, npc_spec_funs, logging_admin -->
 
 <!-- SUBSYSTEM: affects_saves START -->
-### affects_saves — Parity Audit 2025-09-06
+### affects_saves — Parity Audit 2025-09-09
 STATUS: completion:❌ implementation:absent correctness:fails (confidence 0.60)
 KEY RISKS: flags, side_effects
 TASKS:
+- [P0] Define ROM affect flag constants via IntFlag — acceptance: enumeration matches merc.h bit values
 - [P0] Implement affect application/removal with bit flags — acceptance: unit test toggles AFF_BLIND on/off
 - [P0] Implement saving throw resolution using number_mm — acceptance: deterministic pass/fail test
 - [P1] Persist affects to character saves with correct bit widths — acceptance: save/load round trip preserves flags
 - [P1] Integrate affect timers into game update loop — acceptance: tick test expires affect after duration
 NOTES:
 - `Character` dataclass defines `affected_by` and `saving_throw` without mechanics
-- No tests cover affect or saving throw behavior
+- Added `AffectFlag` enum with `AFF_BLIND` bit and basic unit test
+- Applied tiny fix: added `AffectFlag.BLIND` and test
 <!-- SUBSYSTEM: affects_saves END -->
 
 <!-- SUBSYSTEM: socials START -->

--- a/mud/models/constants.py
+++ b/mud/models/constants.py
@@ -1,7 +1,10 @@
-from enum import IntEnum
+from enum import IntEnum, IntFlag  # START affects_saves
+# END affects_saves
+
 
 class Direction(IntEnum):
     """Mapping of direction constants from merc.h"""
+
     NORTH = 0
     EAST = 1
     SOUTH = 2
@@ -9,8 +12,10 @@ class Direction(IntEnum):
     UP = 4
     DOWN = 5
 
+
 class Sector(IntEnum):
     """Sector types from merc.h"""
+
     INSIDE = 0
     CITY = 1
     FIELD = 2
@@ -24,8 +29,10 @@ class Sector(IntEnum):
     DESERT = 10
     MAX = 11
 
+
 class Position(IntEnum):
     """Character positions from merc.h"""
+
     DEAD = 0
     MORTAL = 1
     INCAP = 2
@@ -36,8 +43,10 @@ class Position(IntEnum):
     FIGHTING = 7
     STANDING = 8
 
+
 class WearLocation(IntEnum):
     """Equipment wear locations from merc.h"""
+
     NONE = -1
     LIGHT = 0
     FINGER_L = 1
@@ -59,8 +68,10 @@ class WearLocation(IntEnum):
     HOLD = 17
     FLOAT = 18
 
+
 class Sex(IntEnum):
     """Biological sex of a character"""
+
     NONE = 0
     MALE = 1
     FEMALE = 2
@@ -69,6 +80,7 @@ class Sex(IntEnum):
 
 class Size(IntEnum):
     """Character sizes"""
+
     TINY = 0
     SMALL = 1
     MEDIUM = 2
@@ -79,6 +91,7 @@ class Size(IntEnum):
 
 class ItemType(IntEnum):
     """Common object types"""
+
     LIGHT = 1
     SCROLL = 2
     WAND = 3
@@ -108,3 +121,11 @@ class ItemType(IntEnum):
     GEM = 32
     JEWELRY = 33
     JUKEBOX = 34
+
+
+# START affects_saves
+class AffectFlag(IntFlag):
+    BLIND = 0x00000001
+
+
+# END affects_saves

--- a/port.instructions.md
+++ b/port.instructions.md
@@ -34,6 +34,9 @@
 - RULE: Track affects and saving throws with bitmask flags; avoid Python booleans.
   RATIONALE: ROM uses fixed-width bit flags; parity requires bitwise operations.
   EXAMPLE: ch.affected_by |= AFF_BLIND
+- RULE: Define affect flags via `IntFlag` with explicit bit values; forbid magic numbers.
+  RATIONALE: Ensures flag widths match ROM and improves readability.
+  EXAMPLE: class AffectFlag(IntFlag): BLIND = 0x00000001
 - RULE: Dispatch social commands via registry loaded from ROM `social.are`; forbid hard-coded emote strings.
   RATIONALE: Maintains ROM social messaging and target handling.
   EXAMPLE: social = social_registry["smile"]; social.execute(ch, victim)

--- a/tests/test_affects.py
+++ b/tests/test_affects.py
@@ -1,0 +1,14 @@
+# START affects_saves
+from mud.models.character import Character
+from mud.models.constants import AffectFlag
+
+
+def test_affect_flag_toggle():
+    ch = Character()
+    ch.affected_by |= AffectFlag.BLIND
+    assert ch.affected_by & AffectFlag.BLIND
+    ch.affected_by &= ~AffectFlag.BLIND
+    assert ch.affected_by == 0
+
+
+# END affects_saves


### PR DESCRIPTION
## Summary
- add `AffectFlag` enum with `AFF_BLIND`
- document affects_saves audit tasks and rule for IntFlag
- basic unit test toggling `AFF_BLIND`

## Testing
- `ruff check mud/models/constants.py tests/test_affects.py`
- `ruff format --check mud/models/constants.py tests/test_affects.py`
- `mypy --strict .` *(fails: 323 errors, missing type hints and stubs)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bcbcf1940883209082aa31d6595cd5