### PR TITLE
parity: socials — audit notes, tasks, rules (+tiny fix)

### DIFF
--- a/PYTHON_PORT_PLAN.md
+++ b/PYTHON_PORT_PLAN.md
@@ -1,4 +1,4 @@
-<!-- LAST-PROCESSED: affects_saves -->
+<!-- LAST-PROCESSED: socials -->
 <!-- DO-NOT-SELECT-SECTIONS: 8,10 -->
 <!-- SUBSYSTEM-CATALOG: combat, skills_spells, affects_saves, command_interpreter, socials, channels, wiznet_imm,
 world_loader, resets, weather, time_daynight, movement_encumbrance, stats_position, shops_economy, boards_notes,
@@ -62,7 +62,7 @@ NOTES:
 
 <!-- SUBSYSTEM: socials START -->
 ### socials — Parity Audit 2025-09-06
-STATUS: completion:❌ implementation:partial correctness:unknown (confidence 0.55)
+STATUS: completion:❌ implementation:partial correctness:unknown (confidence 0.58)
 KEY RISKS: file_formats, side_effects
 TASKS:
 - [P0] Load socials into registry and dispatch via command table — acceptance: pytest validates `smile` output to actor and room
@@ -70,8 +70,10 @@ TASKS:
 - [P1] Convert `social.are` to JSON with fixed field widths — acceptance: golden file matches ROM layout
 - [P1] Achieve ≥80% test coverage for socials — acceptance: coverage report ≥80%
 NOTES:
-- `Social` dataclass defined without registry or dispatcher hook
+- `Social` dataclass lacked registry; added `social_registry` placeholder and register function
+- `rg` shows no dispatcher integration or placeholder logic
 - `social.are` exists but is never loaded
+- Applied tiny fix: added registry and unit test
 <!-- SUBSYSTEM: socials END -->
 
 <!-- SUBSYSTEM: wiznet_imm START -->

--- a/mud/models/social.py
+++ b/mud/models/social.py
@@ -21,3 +21,12 @@ class Social:
     @classmethod
     def from_json(cls, data: SocialJson) -> "Social":
         return cls(**data.to_dict())
+
+
+# placeholder registry to track loaded socials
+social_registry: dict[str, Social] = {}
+
+
+def register_social(social: Social) -> None:
+    """Register a social by its lowercase name."""
+    social_registry[social.name.lower()] = social

--- a/port.instructions.md
+++ b/port.instructions.md
@@ -40,6 +40,9 @@
 - RULE: Dispatch social commands via registry loaded from ROM `social.are`; forbid hard-coded emote strings.
   RATIONALE: Maintains ROM social messaging and target handling.
   EXAMPLE: social = social_registry["smile"]; social.execute(ch, victim)
+- RULE: Expand social messages with ROM placeholders (`$n`, `$N`, `$mself`) before dispatch.
+  RATIONALE: Ensures actor and target names/pronouns match ROM outputs.
+  EXAMPLE: expand_social("$n smiles at you.", ch, vict)
 - RULE: Advance world time using ROM `time_info`; emit sunrise/sunset messages on `PULSE_TICK`.
   RATIONALE: Day/night transitions affect light levels and time-based effects.
   EXAMPLE: time_info.update(); broadcast("The sun rises in the east.")

--- a/tests/test_runtime_models.py
+++ b/tests/test_runtime_models.py
@@ -43,6 +43,15 @@ def test_social_from_json():
     assert social.char_no_arg == "You smile."
 
 
+def test_register_social():
+    data = SocialJson(name="wave", char_no_arg="You wave.")
+    social = Social.from_json(data)
+    from mud.models.social import social_registry, register_social
+
+    register_social(social)
+    assert social_registry["wave"] is social
+
+
 def test_board_from_json():
     data = BoardJson(
         name="general",


### PR DESCRIPTION
## Summary
- document socials audit in port plan and capture tiny registry fix
- enforce placeholder-based social expansion rule in port instructions
- add social registry placeholder and registration test

## Testing
- `ruff check mud/models/social.py tests/test_runtime_models.py`
- `ruff format mud/models/social.py tests/test_runtime_models.py --check`
- `mypy --strict mud/models/social.py tests/test_runtime_models.py` *(fails: Need type annotation for "room_registry"...)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bcc15b48508320967fbb1c85173e0b