### PR TITLE
parity: affects_saves audit with helper methods

### DIFF
--- a/PYTHON_PORT_PLAN.md
+++ b/PYTHON_PORT_PLAN.md
@@ -1,4 +1,4 @@
-<!-- LAST-PROCESSED: world_loader -->
+<!-- LAST-PROCESSED: affects_saves -->
 <!-- DO-NOT-SELECT-SECTIONS: 8,10 -->
 <!-- SUBSYSTEM-CATALOG: combat, skills_spells, affects_saves, command_interpreter, socials, channels, wiznet_imm,
 world_loader, resets, weather, time_daynight, movement_encumbrance, stats_position, shops_economy, boards_notes,
@@ -15,7 +15,7 @@ This document outlines the steps needed to port the remaining ROM 2.4 QuickMUD C
 |---|---|---|---|
 | combat | present_wired | mud/combat/engine.py:9 | tests/test_combat.py |
 | skills_spells | present_wired | mud/skills/registry.py:13 | tests/test_skill_registry.py |
-| affects_saves | stub_or_partial | mud/models/character.py:52,60 | — |
+| affects_saves | stub_or_partial | mud/models/constants.py:127-132; mud/models/character.py:99-105 | tests/test_affects.py |
 | command_interpreter | present_wired | mud/commands/dispatcher.py:29-55 | tests/test_commands.py |
 | socials | stub_or_partial | mud/models/social.py:8-42 | — |
 | channels | present_wired | mud/commands/communication.py:8-55 | tests/test_communication.py |
@@ -46,20 +46,20 @@ This document outlines the steps needed to port the remaining ROM 2.4 QuickMUD C
 
 <!-- SUBSYSTEM: affects_saves START -->
 ### affects_saves — Parity Audit 2025-09-06
-STATUS: completion:❌ implementation:absent correctness:fails (confidence 0.60)
+STATUS: completion:❌ implementation:partial correctness:unknown (confidence 0.60)
 KEY RISKS: flags, RNG
 TASKS:
-- [P0] Define ROM affect flag constants via IntFlag — acceptance: enumeration matches merc.h bit values
-- [P0] Implement affect application/removal with bit flags — acceptance: unit test toggles AFF_BLIND on/off
-- [P0] Implement saving throw resolution using number_mm — acceptance: deterministic pass/fail test
+- [P0] Enumerate all ROM affect flags via IntFlag — acceptance: enumeration matches merc.h bit values
+- [P0] Implement saving throw resolution using number_mm and c_div — acceptance: deterministic pass/fail test
+- [P0] Apply and remove affects through helpers — acceptance: unit test toggles multiple flags and updates stats
 - [P1] Persist affects to character saves with correct bit widths — acceptance: save/load round trip preserves flags
 - [P2] Achieve ≥80% test coverage for affects_saves — acceptance: coverage report ≥80%
 NOTES:
 - `Character.affected_by` and `saving_throw` fields lack mechanics
 - `AffectFlag` defines BLIND and INVISIBLE only
-- Applied tiny fix: added INVISIBLE flag constant
+- Applied tiny fix: added `add_affect`/`remove_affect` helpers
 - No saving throw or affect apply functions present
-- Existing unit test toggles BLIND bit directly
+- Existing unit test toggles BLIND bit via helpers
 <!-- SUBSYSTEM: affects_saves END -->
 
 <!-- SUBSYSTEM: socials START -->

--- a/mud/models/character.py
+++ b/mud/models/character.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict, TYPE_CHECKING
 
+from mud.models.constants import AffectFlag
+
 if TYPE_CHECKING:
     from mud.models.object import Object
     from mud.models.room import Room
@@ -93,6 +95,14 @@ class Character:
         if obj in self.inventory:
             self.inventory.remove(obj)
         self.equipment[slot] = obj
+
+# START affects_saves
+    def add_affect(self, flag: AffectFlag) -> None:
+        self.affected_by |= flag
+
+    def remove_affect(self, flag: AffectFlag) -> None:
+        self.affected_by &= ~flag
+# END affects_saves
 
 
 character_registry: list[Character] = []

--- a/port.instructions.md
+++ b/port.instructions.md
@@ -37,6 +37,9 @@
 - RULE: Define affect flags via `IntFlag` with explicit bit values; forbid magic numbers.
   RATIONALE: Ensures flag widths match ROM and improves readability.
   EXAMPLE: class AffectFlag(IntFlag): BLIND = 0x00000001
+- RULE: Manipulate character affects via `add_affect`/`remove_affect`; forbid direct bit twiddling in game logic.
+  RATIONALE: Central helpers preserve future side effects and keep flag math consistent.
+  EXAMPLE: ch.add_affect(AffectFlag.BLIND)
 - RULE: Dispatch social commands via registry loaded from ROM `social.are`; forbid hard-coded emote strings.
   RATIONALE: Maintains ROM social messaging and target handling.
   EXAMPLE: social = social_registry["smile"]; social.execute(ch, victim)

--- a/tests/test_affects.py
+++ b/tests/test_affects.py
@@ -5,9 +5,9 @@ from mud.models.constants import AffectFlag
 
 def test_affect_flag_toggle():
     ch = Character()
-    ch.affected_by |= AffectFlag.BLIND
+    ch.add_affect(AffectFlag.BLIND)
     assert ch.affected_by & AffectFlag.BLIND
-    ch.affected_by &= ~AffectFlag.BLIND
+    ch.remove_affect(AffectFlag.BLIND)
     assert ch.affected_by == 0
 
 


### PR DESCRIPTION
## Summary
- add `add_affect`/`remove_affect` helpers to Character and update tests
- record affects_saves audit tasks and rule about using helpers

## Testing
- `ruff check .` *(fails: F401 unused imports, F821 undefined names)*
- `ruff format --check .` *(fails: would reformat multiple files)*
- `mypy --strict .` *(fails: missing type annotations and library stubs)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bcf5e70e448320b80fc15b28279ce3