### PR TITLE
parity: affects_saves and npc_spec_funs — audit updates

### DIFF
--- a/mud/spec_funs.py
+++ b/mud/spec_funs.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
-from typing import Callable, Dict, Any
+from typing import Any, Callable
 
-spec_fun_registry: Dict[str, Callable[..., Any]] = {}
+spec_fun_registry: dict[str, Callable[..., Any]] = {}
 
 def register_spec_fun(name: str, func: Callable[..., Any]) -> None:
-    spec_fun_registry[name] = func
+    """Register *func* under *name*, storing key in lowercase."""
+    spec_fun_registry[name.lower()] = func
+
+def get_spec_fun(name: str) -> Callable[..., Any] | None:
+    """Return a spec_fun for *name* using case-insensitive lookup."""
+    return spec_fun_registry.get(name.lower())

--- a/port.instructions.md
+++ b/port.instructions.md
@@ -115,6 +115,9 @@
 - RULE: IMC code is feature-flagged; if disabled at runtime, keep loader and protocol parsers in place with no-op dispatch.
   RATIONALE: Preserve wire compatibility without enabling cross-MUD chat.
   EXAMPLE: IMC_ENABLED=False → sockets never opened; parsers tested.
+- RULE: Register `spec_fun` names in lowercase for case-insensitive lookup.
+  RATIONALE: ROM's `spec_lookup` compares names without regard to case.
+  EXAMPLE: register_spec_fun("Spec_Cast_Adept", func)
 <!-- RULES-END -->
 
 ## Ops Playbook (human tips the bot won’t manage)

--- a/tests/test_spec_funs.py
+++ b/tests/test_spec_funs.py
@@ -1,0 +1,18 @@
+from mud.spec_funs import get_spec_fun, register_spec_fun, spec_fun_registry
+
+
+def test_case_insensitive_lookup() -> None:
+    called: list[tuple[object, ...]] = []
+
+    def dummy(*args: object) -> None:  # placeholder spec_fun
+        called.append(args)
+    prev = dict(spec_fun_registry)
+    try:
+        register_spec_fun("Spec_Test", dummy)
+
+        assert get_spec_fun("spec_test") is dummy
+        assert get_spec_fun("SPEC_TEST") is dummy
+        assert called == []
+    finally:
+        spec_fun_registry.clear()
+        spec_fun_registry.update(prev)


### PR DESCRIPTION
## Summary
- capture doc and legacy file references for area and player saves in coverage matrix
- reorder Next Actions list and record spec_fun lookup helper
- add `get_spec_fun` helper for case-insensitive NPC spec function retrieval
- add regression test for case-insensitive spec_fun registry lookup
- ensure spec_fun registry state is restored after case-insensitive lookup test

## Testing
- `ruff check .` *(fails: unused imports, undefined names)*
- `ruff format --check .` *(fails: 71 files would be reformatted)*
- `mypy --strict .` *(fails: missing library stubs and type annotations)*
- `pytest -q` *(fails: ModuleNotFoundError: jsonschema)*

------
https://chatgpt.com/codex/tasks/task_b_68bddfc96504832084cd34d06c595df9