### PR TITLE
exec: mob_programs — complete mob command parity

### DIFF
--- a/mud/mob_cmds.py
+++ b/mud/mob_cmds.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, TYPE_CHECKING
+from typing import Callable, Iterable, TYPE_CHECKING
+
+from mud.utils import rng_mm
 
 if TYPE_CHECKING:
     from mud.models.character import Character
+    from mud.models.object import Object
+    from mud.models.room import Room
 
 
 CommandFunc = Callable[["Character", str], None]
@@ -26,16 +30,92 @@ def _split_command(argument: str) -> tuple[str, str]:
     return command, rest
 
 
+def _iter_room_people(room: "Room" | None) -> Iterable["Character"]:
+    if room is None:
+        return []
+    return list(getattr(room, "people", []) or [])
+
+
+def _match_char_name(char: "Character", token: str) -> bool:
+    name = getattr(char, "name", None)
+    if not name or not token:
+        return False
+    return name.lower().startswith(token.lower())
+
+
 def _find_char_in_room(ch: "Character", name: str) -> "Character" | None:
     room = getattr(ch, "room", None)
-    if room is None:
-        return None
-    lowered = name.lower()
-    for occupant in getattr(room, "people", []):
-        occupant_name = getattr(occupant, "name", None)
-        if occupant_name and occupant_name.lower().startswith(lowered):
+    for occupant in _iter_room_people(room):
+        if _match_char_name(occupant, name):
             return occupant
     return None
+
+
+def _find_char_world(name: str) -> "Character" | None:
+    if not name:
+        return None
+    from mud.models.character import character_registry
+
+    for candidate in list(character_registry):
+        if _match_char_name(candidate, name):
+            return candidate
+    return None
+
+
+def _get_room_by_vnum(vnum: int) -> "Room" | None:
+    from mud.registry import room_registry
+
+    return room_registry.get(vnum)
+
+
+def _find_location(ch: "Character", token: str) -> "Room" | None:
+    if not token:
+        return None
+    if token.lower() == "here":
+        return getattr(ch, "room", None)
+    try:
+        vnum = int(token)
+    except ValueError:
+        target = _find_char_world(token)
+        return getattr(target, "room", None)
+    return _get_room_by_vnum(vnum)
+
+
+def _move_to_room(ch: "Character", destination: "Room") -> None:
+    current = getattr(ch, "room", None)
+    if current is destination:
+        return
+    if current is not None:
+        remover = getattr(current, "remove_character", None)
+        if callable(remover):
+            remover(ch)
+    adder = getattr(destination, "add_character", None)
+    if callable(adder):
+        adder(ch)
+    else:
+        destination.people.append(ch)
+        ch.room = destination
+
+
+def _append_message(target: "Character", message: str) -> None:
+    if not hasattr(target, "messages"):
+        return
+    target.messages.append(message)
+
+
+def _broadcast(
+    room: "Room" | None,
+    message: str,
+    *,
+    exclude: Iterable[object] | None = None,
+) -> None:
+    if not room or not message:
+        return
+    excluded = tuple(exclude or ())
+    for char in _iter_room_people(room):
+        if any(char is other for other in excluded):
+            continue
+        _append_message(char, message)
 
 
 def do_mpecho(ch: "Character", argument: str) -> None:
@@ -47,6 +127,22 @@ def do_mpecho(ch: "Character", argument: str) -> None:
     room.broadcast(argument, exclude=ch)
 
 
+def do_mpasound(ch: "Character", argument: str) -> None:
+    if not argument:
+        return
+    room = getattr(ch, "room", None)
+    if room is None:
+        return
+    exits = list(getattr(room, "exits", []) or [])
+    for exit_obj in exits:
+        if exit_obj is None:
+            continue
+        target_room = getattr(exit_obj, "to_room", None)
+        if target_room is None or target_room is room:
+            continue
+        _broadcast(target_room, argument)
+
+
 def do_mpgecho(ch: "Character", argument: str) -> None:
     if not argument:
         return
@@ -55,6 +151,50 @@ def do_mpgecho(ch: "Character", argument: str) -> None:
     for target in character_registry:
         if hasattr(target, "messages"):
             target.messages.append(argument)
+
+
+def do_mpzecho(ch: "Character", argument: str) -> None:
+    if not argument:
+        return
+    room = getattr(ch, "room", None)
+    if room is None:
+        return
+    area = getattr(room, "area", None)
+    if area is None:
+        return
+    from mud.models.character import character_registry
+
+    for target in list(character_registry):
+        target_room = getattr(target, "room", None)
+        if target_room is None:
+            continue
+        if getattr(target_room, "area", None) is not area:
+            continue
+        _append_message(target, argument)
+
+
+def do_mpechoaround(ch: "Character", argument: str) -> None:
+    target_name, _, message = argument.partition(" ")
+    if not target_name or not message.strip():
+        return
+    victim = _find_char_in_room(ch, target_name)
+    if victim is None:
+        return
+    room = getattr(ch, "room", None)
+    for occupant in _iter_room_people(room):
+        if occupant is ch or occupant is victim:
+            continue
+        _append_message(occupant, message.strip())
+
+
+def do_mpechoat(ch: "Character", argument: str) -> None:
+    target_name, _, message = argument.partition(" ")
+    if not target_name or not message.strip():
+        return
+    victim = _find_char_in_room(ch, target_name)
+    if victim is None:
+        return
+    _append_message(victim, message.strip())
 
 
 def do_mpcall(ch: "Character", argument: str) -> None:
@@ -89,9 +229,312 @@ def do_mpcancel(ch: "Character", argument: str) -> None:
     setattr(ch, "mprog_delay", 0)
 
 
+def do_mpmload(ch: "Character", argument: str) -> None:
+    parts = argument.split()
+    if not parts:
+        return
+    try:
+        vnum = int(parts[0])
+    except ValueError:
+        return
+    room = getattr(ch, "room", None)
+    if room is None:
+        return
+    from mud.spawning.mob_spawner import spawn_mob
+
+    mob = spawn_mob(vnum)
+    if mob is None:
+        return
+    setattr(mob, "is_npc", True)
+    proto = getattr(mob, "prototype", None)
+    default_pos = getattr(proto, "default_pos", getattr(mob, "position", None))
+    if default_pos is not None:
+        setattr(mob, "default_pos", default_pos)
+    if not hasattr(mob, "messages"):
+        setattr(mob, "messages", [])
+    programs = getattr(getattr(mob, "prototype", None), "mprogs", None)
+    if programs is not None and not getattr(mob, "mob_programs", None):
+        setattr(mob, "mob_programs", list(programs))
+    room.add_mob(mob)
+
+
+def do_mpoload(ch: "Character", argument: str) -> None:
+    parts = argument.split()
+    if not parts:
+        return
+    try:
+        vnum = int(parts[0])
+    except ValueError:
+        return
+    room = getattr(ch, "room", None)
+    if room is None:
+        return
+    mode_token = ""
+    if len(parts) >= 2:
+        if parts[1].isdigit():
+            if len(parts) >= 3:
+                mode_token = parts[2]
+        else:
+            mode_token = parts[1]
+    mode = mode_token.lower()
+    from mud.spawning.obj_spawner import spawn_object
+
+    obj = spawn_object(vnum)
+    if obj is None:
+        return
+    if mode.startswith("r"):
+        room.add_object(obj)
+        return
+    inventory = getattr(ch, "inventory", None)
+    if inventory is None:
+        inventory = []
+        setattr(ch, "inventory", inventory)
+    inventory.append(obj)
+
+
+def _resolve_transfer_location(ch: "Character", token: str) -> "Room" | None:
+    if not token:
+        return getattr(ch, "room", None)
+    return _find_location(ch, token)
+
+
+def _transfer_character(ch: "Character", victim: "Character", dest: "Room") -> None:
+    if getattr(victim, "room", None) is dest:
+        return
+    if getattr(victim, "fighting", None) is not None:
+        setattr(victim, "fighting", None)
+    current = getattr(victim, "room", None)
+    if current is not None:
+        remover = getattr(current, "remove_character", None)
+        if callable(remover):
+            remover(victim)
+    adder = getattr(dest, "add_character", None)
+    if callable(adder):
+        adder(victim)
+    else:
+        dest.people.append(victim)
+        victim.room = dest
+
+
+def do_mpgoto(ch: "Character", argument: str) -> None:
+    destination = _find_location(ch, argument.strip())
+    if destination is None:
+        return
+    if getattr(ch, "fighting", None) is not None:
+        setattr(ch, "fighting", None)
+    _move_to_room(ch, destination)
+
+
+def do_mptransfer(ch: "Character", argument: str) -> None:
+    first, _, rest = argument.partition(" ")
+    target_name = first.strip()
+    location_token = rest.strip()
+    if not target_name:
+        return
+    destination = _resolve_transfer_location(ch, location_token)
+    if destination is None:
+        return
+    if target_name.lower() == "all":
+        for occupant in list(_iter_room_people(getattr(ch, "room", None))):
+            if getattr(occupant, "is_npc", True):
+                continue
+            _transfer_character(ch, occupant, destination)
+        return
+    victim = _find_char_world(target_name)
+    if victim is None:
+        return
+    _transfer_character(ch, victim, destination)
+
+
+def do_mpforce(ch: "Character", argument: str) -> None:
+    target_name, _, command = argument.partition(" ")
+    if not target_name or not command.strip():
+        return
+    from mud.commands.dispatcher import process_command
+
+    if target_name.lower() == "all":
+        for occupant in _iter_room_people(getattr(ch, "room", None)):
+            if occupant is ch:
+                continue
+            process_command(occupant, command)
+        return
+    victim = _find_char_in_room(ch, target_name)
+    if victim is None or victim is ch:
+        return
+    process_command(victim, command)
+
+
+def do_mpkill(ch: "Character", argument: str) -> None:
+    target = _find_char_in_room(ch, argument.strip())
+    if target is None:
+        return
+    if getattr(target, "is_npc", False):
+        return
+    if getattr(ch, "fighting", None) is not None:
+        return
+    from mud.combat import multi_hit
+
+    multi_hit(ch, target)
+
+
+def do_mpassist(ch: "Character", argument: str) -> None:
+    ally = _find_char_in_room(ch, argument.strip())
+    if ally is None:
+        return
+    target = getattr(ally, "fighting", None)
+    if target is None:
+        return
+    from mud.combat import multi_hit
+
+    multi_hit(ch, target)
+
+
+def _match_object(obj: "Object", token: str) -> bool:
+    proto = getattr(obj, "prototype", None)
+    names: list[str] = []
+    if proto is not None:
+        for attr in ("name", "short_descr"):
+            value = getattr(proto, attr, None)
+            if value:
+                names.extend(str(value).lower().split())
+    if hasattr(obj, "name") and getattr(obj, "name", None):
+        names.extend(str(obj.name).lower().split())
+    token = token.lower()
+    return any(name.startswith(token) or token in name for name in names)
+
+
+def do_mpjunk(ch: "Character", argument: str) -> None:
+    token = argument.strip()
+    if not token:
+        return
+    inventory = list(getattr(ch, "inventory", []) or [])
+    equipment = dict(getattr(ch, "equipment", {}) or {})
+
+    def _remove(obj: "Object") -> None:
+        if obj in inventory:
+            inventory.remove(obj)
+        for slot, equipped in list(equipment.items()):
+            if equipped is obj:
+                equipment.pop(slot, None)
+
+    if token.lower() == "all":
+        for obj in list(inventory):
+            _remove(obj)
+        setattr(ch, "inventory", [])
+        setattr(ch, "equipment", equipment)
+        return
+    if token.lower().startswith("all."):
+        suffix = token[4:]
+        for obj in list(inventory):
+            if _match_object(obj, suffix):
+                _remove(obj)
+        setattr(ch, "inventory", inventory)
+        setattr(ch, "equipment", equipment)
+        return
+    for obj in list(inventory):
+        if _match_object(obj, token):
+            _remove(obj)
+            break
+    setattr(ch, "inventory", inventory)
+    setattr(ch, "equipment", equipment)
+
+
+def do_mpdamage(ch: "Character", argument: str) -> None:
+    parts = argument.split()
+    if len(parts) < 3:
+        return
+    target_token, min_raw, max_raw, *rest = parts
+    try:
+        low = int(min_raw)
+        high = int(max_raw)
+    except ValueError:
+        return
+    if low > high:
+        low, high = high, low
+    kill = bool(rest)
+
+    def _apply_damage(victim: "Character") -> None:
+        amount = rng_mm.number_range(low, high)
+        if not kill:
+            amount = min(amount, max(0, getattr(victim, "hit", 0)))
+        victim.hit = max(0, getattr(victim, "hit", 0) - amount)
+
+    if target_token.lower() == "all":
+        for occupant in _iter_room_people(getattr(ch, "room", None)):
+            if occupant is ch:
+                continue
+            _apply_damage(occupant)
+        return
+    victim = _find_char_in_room(ch, target_token)
+    if victim is None:
+        return
+    _apply_damage(victim)
+
+
+def do_mpremove(ch: "Character", argument: str) -> None:
+    target_name, _, obj_token = argument.partition(" ")
+    if not target_name or not obj_token.strip():
+        return
+    victim = _find_char_in_room(ch, target_name)
+    if victim is None:
+        return
+    inventory = list(getattr(victim, "inventory", []) or [])
+    all_flag = obj_token.strip().lower() == "all"
+    vnum = None
+    if not all_flag:
+        try:
+            vnum = int(obj_token.strip())
+        except ValueError:
+            return
+    new_inventory: list["Object"] = []
+    for obj in inventory:
+        proto = getattr(obj, "prototype", None)
+        proto_vnum = getattr(proto, "vnum", None)
+        if all_flag or (proto_vnum is not None and proto_vnum == vnum):
+            continue
+        new_inventory.append(obj)
+    setattr(victim, "inventory", new_inventory)
+
+
+def do_mpflee(ch: "Character", argument: str) -> None:
+    if getattr(ch, "fighting", None) is not None:
+        return
+    room = getattr(ch, "room", None)
+    if room is None:
+        return
+    from mud.models.constants import EX_CLOSED
+
+    exits = list(getattr(room, "exits", []) or [])
+    for exit_obj in exits:
+        if exit_obj is None:
+            continue
+        if getattr(exit_obj, "exit_info", 0) & EX_CLOSED:
+            continue
+        target_room = getattr(exit_obj, "to_room", None)
+        if target_room is None:
+            continue
+        _move_to_room(ch, target_room)
+        return
+
+
 _COMMANDS: list[MobCommand] = [
+    MobCommand("asound", do_mpasound),
     MobCommand("echo", do_mpecho),
     MobCommand("gecho", do_mpgecho),
+    MobCommand("zecho", do_mpzecho),
+    MobCommand("echoaround", do_mpechoaround),
+    MobCommand("echoat", do_mpechoat),
+    MobCommand("mload", do_mpmload),
+    MobCommand("oload", do_mpoload),
+    MobCommand("goto", do_mpgoto),
+    MobCommand("transfer", do_mptransfer),
+    MobCommand("force", do_mpforce),
+    MobCommand("kill", do_mpkill),
+    MobCommand("assist", do_mpassist),
+    MobCommand("junk", do_mpjunk),
+    MobCommand("damage", do_mpdamage),
+    MobCommand("remove", do_mpremove),
+    MobCommand("flee", do_mpflee),
     MobCommand("call", do_mpcall),
     MobCommand("delay", do_mpdelay),
     MobCommand("cancel", do_mpcancel),

--- a/tests/test_mobprog_commands.py
+++ b/tests/test_mobprog_commands.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import pytest
+
+from mud import mob_cmds
+from mud.models.area import Area
+from mud.models.character import Character, character_registry
+from mud.models.mob import MobIndex
+from mud.models.obj import ObjIndex
+from mud.models.object import Object
+from mud.models.room import Exit, Room
+from mud.registry import area_registry, mob_registry, obj_registry, room_registry
+
+
+@pytest.fixture(autouse=True)
+def clear_registries():
+    room_registry.clear()
+    mob_registry.clear()
+    obj_registry.clear()
+    area_registry.clear()
+    character_registry.clear()
+    yield
+    room_registry.clear()
+    mob_registry.clear()
+    obj_registry.clear()
+    area_registry.clear()
+    character_registry.clear()
+
+
+def _setup_area(vnum: int = 1) -> tuple[Area, Room, Room]:
+    area = Area(vnum=vnum, name="Test Area")
+    area_registry[vnum] = area
+    room_a = Room(vnum=100 + vnum, name="Room A", area=area)
+    room_b = Room(vnum=200 + vnum, name="Room B", area=area)
+    room_a.exits[0] = Exit(to_room=room_b)  # arbitrary direction linkage
+    room_b.exits[2] = Exit(to_room=room_a)
+    room_registry[room_a.vnum] = room_a
+    room_registry[room_b.vnum] = room_b
+    return area, room_a, room_b
+
+
+def test_mob_broadcast_commands_deliver_expected_messages():
+    area, origin, adjacent = _setup_area()
+    extra_room = Room(vnum=300, name="Room C", area=area)
+    room_registry[extra_room.vnum] = extra_room
+    other_area = Area(vnum=99, name="Elsewhere")
+    area_registry[other_area.vnum] = other_area
+    remote_room = Room(vnum=400, name="Remote", area=other_area)
+    room_registry[remote_room.vnum] = remote_room
+
+    mob = Character(name="Guard", is_npc=True)
+    origin.add_character(mob)
+    character_registry.append(mob)
+
+    scout = Character(name="Scout", is_npc=False)
+    adjacent.add_character(scout)
+    character_registry.append(scout)
+
+    sentinel = Character(name="Sentinel", is_npc=False)
+    extra_room.add_character(sentinel)
+    character_registry.append(sentinel)
+
+    bystander = Character(name="Bystander", is_npc=False)
+    remote_room.add_character(bystander)
+    character_registry.append(bystander)
+
+    victim = Character(name="Hero", is_npc=False)
+    observer = Character(name="Watcher", is_npc=False)
+    origin.add_character(victim)
+    origin.add_character(observer)
+    character_registry.extend([victim, observer])
+
+    mob_cmds.mob_interpret(mob, "asound Alarm!")
+    assert scout.messages[-1] == "Alarm!"
+
+    mob_cmds.mob_interpret(mob, "zecho Brace yourselves!")
+    assert sentinel.messages[-1] == "Brace yourselves!"
+    assert victim.messages[-1] == "Brace yourselves!"
+    assert not bystander.messages
+
+    mob_cmds.mob_interpret(mob, "echoaround Hero Guard growls at you.")
+    assert observer.messages[-1] == "Guard growls at you."
+    assert victim.messages[-1] == "Brace yourselves!"
+
+    mob_cmds.mob_interpret(mob, "echoat Hero You shall not pass.")
+    assert victim.messages[-1] == "You shall not pass."
+
+
+def test_spawn_move_and_force_commands_use_rom_semantics(monkeypatch):
+    _, origin, target = _setup_area()
+
+    mob_proto = MobIndex(vnum=2000, short_descr="test mob")
+    mob_registry[mob_proto.vnum] = mob_proto
+    obj_proto_room = ObjIndex(vnum=3001, short_descr="a room token", name="token")
+    obj_proto_inv = ObjIndex(vnum=3000, short_descr="an inventory charm", name="charm")
+    obj_registry[obj_proto_room.vnum] = obj_proto_room
+    obj_registry[obj_proto_inv.vnum] = obj_proto_inv
+
+    controller = Character(name="Controller", is_npc=True)
+    origin.add_character(controller)
+    character_registry.append(controller)
+
+    mob_cmds.mob_interpret(controller, "mload 2000")
+    spawned = [
+        occupant
+        for occupant in origin.people
+        if occupant is not controller and getattr(occupant, "prototype", None)
+    ]
+    assert spawned and getattr(spawned[0].prototype, "vnum", None) == 2000
+
+    mob_cmds.mob_interpret(controller, "oload 3000")
+    assert any(getattr(obj.prototype, "vnum", None) == 3000 for obj in controller.inventory)
+
+    mob_cmds.mob_interpret(controller, "oload 3001 R")
+    assert any(getattr(obj.prototype, "vnum", None) == 3001 for obj in origin.contents)
+
+    mob_cmds.mob_interpret(controller, f"goto {target.vnum}")
+    assert controller.room is target
+
+    hero = Character(name="Hero", is_npc=False)
+    origin.add_character(hero)
+    character_registry.append(hero)
+
+    mob_cmds.mob_interpret(controller, "transfer Hero")
+    assert hero.room is controller.room
+
+    forced: list[tuple[str, str]] = []
+
+    def fake_process(char: Character, command: str) -> str:
+        forced.append((char.name, command))
+        return ""
+
+    monkeypatch.setattr("mud.commands.dispatcher.process_command", fake_process)
+
+    mob_cmds.mob_interpret(controller, "force Hero say hello")
+    assert forced == [("Hero", "say hello")]
+
+
+def test_combat_cleanup_commands_handle_inventory_damage_and_escape(monkeypatch):
+    _, start, escape = _setup_area()
+
+    obj_proto_a = ObjIndex(vnum=6000, short_descr="a practice token", name="token")
+    obj_proto_b = ObjIndex(vnum=6001, short_descr="a bronze sword", name="sword")
+    obj_registry[obj_proto_a.vnum] = obj_proto_a
+    obj_registry[obj_proto_b.vnum] = obj_proto_b
+
+    mob = Character(name="Enforcer", is_npc=True)
+    start.add_character(mob)
+    character_registry.append(mob)
+
+    hero = Character(name="Hero", is_npc=False, hit=20, max_hit=20)
+    start.add_character(hero)
+    character_registry.append(hero)
+
+    calls: list[tuple[Character, Character]] = []
+
+    def fake_multi_hit(attacker: Character, target: Character) -> None:
+        calls.append((attacker, target))
+
+    monkeypatch.setattr("mud.combat.multi_hit", fake_multi_hit)
+
+    mob_cmds.mob_interpret(mob, "kill Hero")
+    assert calls[-1] == (mob, hero)
+
+    ally = Character(name="Ally", is_npc=True)
+    ally.fighting = hero
+    start.add_character(ally)
+    mob_cmds.mob_interpret(mob, "assist Ally")
+    assert calls[-1] == (mob, hero)
+
+    token = Object(instance_id=None, prototype=obj_proto_a)
+    sword = Object(instance_id=None, prototype=obj_proto_b)
+    mob.inventory = [token, sword]
+    mob.equipment = {"wield": sword}
+
+    mob_cmds.mob_interpret(mob, "junk token")
+    assert all(getattr(obj.prototype, "vnum", None) != 6000 for obj in mob.inventory)
+
+    mob_cmds.mob_interpret(mob, "junk all")
+    assert mob.inventory == []
+    assert mob.equipment == {}
+
+    monkeypatch.setattr("mud.mob_cmds.rng_mm.number_range", lambda low, high: high)
+
+    mob_cmds.mob_interpret(mob, "damage Hero 3 5")
+    assert hero.hit == 15
+
+    mob_cmds.mob_interpret(mob, "damage Hero 3 5 kill")
+    assert hero.hit == 10
+
+    quest_item = Object(instance_id=None, prototype=ObjIndex(vnum=6100, short_descr="a relic"))
+    spare_item = Object(instance_id=None, prototype=ObjIndex(vnum=6101, short_descr="a spare"))
+    hero.inventory = [quest_item, spare_item]
+
+    mob_cmds.mob_interpret(mob, "remove Hero 6100")
+    assert all(getattr(obj.prototype, "vnum", None) != 6100 for obj in hero.inventory)
+
+    mob_cmds.mob_interpret(mob, "remove Hero all")
+    assert hero.inventory == []
+
+    mob_cmds.mob_interpret(mob, "flee")
+    assert mob.room is escape


### PR DESCRIPTION
## Summary
- port ROM mob program commands for spawning, movement/transfer, broadcasts, and combat cleanup into `mud/mob_cmds.py`
- add regression tests covering broadcast scope, spawn/transfer/force flows, and combat cleanup semantics
- update the mob_programs plan status to mark the [P0] tasks complete with evidence references

## Testing
- ruff check . *(fails: pre-existing repository lint errors and shell script parsing issues)*
- ruff format --check . *(fails: repository-wide formatting drift and shell script parsing issues)*
- mypy --strict . *(fails: scripts/agent_loop.py syntax prevents type checking)*
- pytest -q *(fails: package imports require PYTHONPATH configuration in this environment)*
- PYTHONPATH=. pytest -q tests/test_mobprog_commands.py

------
https://chatgpt.com/codex/tasks/task_b_68d4e8a1e5c083209586f05c6edf1142