### PR TITLE
exec: resets-and-movement — parity fixes

### DIFF
--- a/PYTHON_PORT_PLAN.md
+++ b/PYTHON_PORT_PLAN.md
@@ -63,32 +63,36 @@ This document outlines the steps needed to port the remaining ROM 2.4 QuickMUD C
 
 **Priority P0 Tasks (Required for Functional Parity):**
 
-- [P0] **Area Format Loader: Fix LoadObj/LoadMob State Tracking** (confidence: 0.74)
+- ✅ [P0] **Area Format Loader: Fix LoadObj/LoadMob State Tracking** — done 2025-10-11
 
   - FILES: mud/world/loader.py LoadObj/LoadMob methods, mud/data/area_format_loader.py reset validation
   - ISSUE: Missing LastObj/LastMob index state tracking causing reset validation mismatches
   - C_REF: src/db.c:1842-1950 (load_objects), src/db.c:1650-1741 (load_mobiles) track Last\*
   - ACCEPTANCE: pytest tests/test_area_loader.py::test_midgaard_reset_validation passes
+  EVIDENCE: C src/db.c:1009-1108 (load_resets maintains room context); PY mud/loaders/reset_loader.py:77-157 (validate_resets tracks LastMob/LastObj state with cross-area guard); TEST tests/test_area_loader.py::test_midgaard_reset_validation
 
-- [P0] **Movement System: Follower Cascading Integration** (confidence: 0.55)
+- ✅ [P0] **Movement System: Follower Cascading Integration** — done 2025-10-11
 
   - FILES: mud/actions/movement.py move_char function, mud/character/follower.py cascading logic
   - ISSUE: Follower movement cascade not integrated with main movement flow
   - C_REF: src/act_move.c:127-184 (move_char) calls follower updates inline
   - ACCEPTANCE: Follower follows leader through exits; pytest tests/test_movement.py::test_follower_cascade
+  EVIDENCE: C src/act_move.c:127-184 (move_char cascades followers); PY mud/world/movement.py:38-396 (shared follower mover + portal support); PY mud/commands/movement.py:1-60 (do_enter delegates to portal mover); TEST tests/test_movement.py::test_follower_cascade; TEST tests/test_movement.py::test_followers_enter_portal
 
-- [P0] **Help System: Missing Command Topic Generation** (confidence: 0.70)
+- ✅ [P0] **Help System: Missing Command Topic Generation** — done 2025-10-11
 
   - FILES: mud/systems/help.py get_help method, mud/commands/dispatcher.py help integration
   - ISSUE: No command topic auto-generation when help not found
   - C_REF: src/act_info.c:892-1045 (do_help) generates command help dynamically
   - ACCEPTANCE: 'help cast' shows spell help; 'help unknown' shows command suggestion
+  EVIDENCE: C src/act_info.c:892-1045 (do_help fallback builds command topics); PY mud/commands/help.py:1-159 (command help generation with trust gating); TEST tests/test_help_system.py::test_help_generates_command_topic_when_missing; TEST tests/test_help_system.py::test_help_missing_topic_suggests_commands
 
-- [P0] **Reset System: Execute Integration** (confidence: 0.38)
+- ✅ [P0] **Reset System: Execute Integration** — done 2025-10-11
   - FILES: mud/world/reset_system.py execute methods, mud/game_loop.py area update integration
   - ISSUE: Reset execution not wired to area update cycle
   - C_REF: src/update.c:1234-1389 (area_update) calls reset_area inline
   - ACCEPTANCE: Items/mobs respawn on area reset; pytest tests/test_resets.py::test_execution_cycle
+  EVIDENCE: C src/update.c:1234-1389 (area_update triggers reset_area); PY mud/game_loop.py:143-198 (game_tick invokes reset_tick on area pulse); TEST tests/test_resets.py::test_execution_cycle
 
 ## Parity Gaps & Corrections
 

--- a/mud/commands/movement.py
+++ b/mud/commands/movement.py
@@ -1,7 +1,7 @@
 from mud.models.character import Character
 from mud.models.constants import EX_CLOSED, ItemType
 from mud.registry import room_registry
-from mud.world.movement import move_character
+from mud.world.movement import move_character, move_character_through_portal
 
 
 def do_north(char: Character, args: str = "") -> str:
@@ -57,15 +57,4 @@ def do_enter(char: Character, args: str = "") -> str:
         return "The portal is closed."
 
     dest_vnum = values[3] if len(values) > 3 else 0
-    dest = room_registry.get(int(dest_vnum))
-    if dest is None:
-        return "It doesn't seem to go anywhere."
-
-    # Move character
-    old_room = char.room
-    if char in old_room.people:
-        old_room.people.remove(char)
-    dest.people.append(char)
-    char.room = dest
-    char.wait = max(char.wait, 1)
-    return f"You enter the portal and arrive in {dest.name}."
+    return move_character_through_portal(char, portal)

--- a/mud/loaders/reset_loader.py
+++ b/mud/loaders/reset_loader.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Iterator
 
 from mud.models.room_json import ResetJson
+from mud.registry import mob_registry, obj_registry, room_registry
 
 from .base_loader import BaseTokenizer
 
@@ -54,3 +57,101 @@ def load_resets(tokenizer: BaseTokenizer, area):
 
         reset = ResetJson(command=command, arg1=arg1, arg2=arg2, arg3=arg3, arg4=arg4)
         area.resets.append(reset)
+
+
+def _validate_exit(reset: ResetJson) -> str | None:
+    room_vnum = int(reset.arg1 or 0)
+    direction = int(reset.arg2 or 0)
+    room = room_registry.get(room_vnum)
+    if room is None:
+        return f"Reset D references missing room {room_vnum}"
+    exits = getattr(room, "exits", []) or []
+    if direction < 0 or direction >= len(exits):
+        return f"Reset D has invalid direction {direction} for room {room_vnum}"
+    exit_obj = exits[direction]
+    if exit_obj is None:
+        return f"Reset D points to missing exit at room {room_vnum} dir {direction}"
+    return None
+
+
+def validate_resets(area) -> list[str]:
+    """Validate ROM reset sequencing using LastMob/LastObj tracking."""
+
+    errors: list[str] = []
+
+    min_vnum = int(getattr(area, "min_vnum", 0) or 0)
+    max_vnum = int(getattr(area, "max_vnum", 0) or 0)
+
+    def _is_local(vnum: int) -> bool:
+        if min_vnum == 0 and max_vnum == 0:
+            return True
+        return min_vnum <= vnum <= max_vnum
+
+    last_room_vnum: int | None = None
+    last_mob_vnum: int | None = None
+    last_obj_vnum: int | None = None
+
+    for reset in area.resets:
+        command = (reset.command or "").upper()
+        if command == "M":
+            room_vnum = int(reset.arg3 or 0)
+            mob_vnum = int(reset.arg1 or 0)
+            if mob_vnum not in mob_registry and _is_local(mob_vnum):
+                errors.append(f"Reset M references missing mob {mob_vnum}")
+            if room_vnum not in room_registry and _is_local(room_vnum):
+                errors.append(f"Reset M references missing room {room_vnum}")
+            last_room_vnum = room_vnum if room_vnum in room_registry else None
+            last_mob_vnum = mob_vnum if mob_vnum in mob_registry else None
+            last_obj_vnum = None
+        elif command == "O":
+            obj_vnum = int(reset.arg1 or 0)
+            room_vnum = int(reset.arg3 or 0)
+            if obj_vnum not in obj_registry and _is_local(obj_vnum):
+                errors.append(f"Reset O references missing object {obj_vnum}")
+            if room_vnum not in room_registry and _is_local(room_vnum):
+                errors.append(f"Reset O references missing room {room_vnum}")
+            last_room_vnum = room_vnum if room_vnum in room_registry else last_room_vnum
+            last_obj_vnum = obj_vnum if obj_vnum in obj_registry else last_obj_vnum
+        elif command == "P":
+            obj_vnum = int(reset.arg1 or 0)
+            container_vnum = int(reset.arg3 or 0)
+            if obj_vnum not in obj_registry and _is_local(obj_vnum):
+                errors.append(f"Reset P references missing object {obj_vnum}")
+            target_vnum: int | None
+            if container_vnum:
+                target_vnum = container_vnum
+            else:
+                target_vnum = last_obj_vnum
+            if not target_vnum or (
+                target_vnum not in obj_registry and _is_local(int(target_vnum))
+            ):
+                errors.append(
+                    f"Reset P has no container context for object {obj_vnum}"
+                )
+            last_obj_vnum = obj_vnum if obj_vnum in obj_registry else last_obj_vnum
+        elif command in {"G", "E"}:
+            obj_vnum = int(reset.arg1 or 0)
+            if obj_vnum not in obj_registry and _is_local(obj_vnum):
+                errors.append(f"Reset {command} references missing object {obj_vnum}")
+            if last_mob_vnum is None or last_mob_vnum not in mob_registry:
+                errors.append(
+                    f"Reset {command} lacks LastMob context before object {obj_vnum}"
+                )
+            last_obj_vnum = obj_vnum if obj_vnum in obj_registry else last_obj_vnum
+        elif command == "D":
+            error = _validate_exit(reset)
+            if error:
+                errors.append(error)
+            last_room_vnum = int(reset.arg1 or 0) if int(reset.arg1 or 0) in room_registry else last_room_vnum
+            last_obj_vnum = None
+        elif command == "R":
+            room_vnum = int(reset.arg1 or 0)
+            if room_vnum not in room_registry and _is_local(room_vnum):
+                errors.append(f"Reset R references missing room {room_vnum}")
+            last_room_vnum = room_vnum if room_vnum in room_registry else last_room_vnum
+            last_obj_vnum = None
+        else:
+            # Unknown reset command: record but continue.
+            errors.append(f"Reset {command} is not recognised for validation")
+
+    return errors

--- a/mud/scripts/convert_are_to_json.py
+++ b/mud/scripts/convert_are_to_json.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 from mud.loaders.area_loader import load_area_file
+from mud.loaders.reset_loader import validate_resets
 from mud.models.constants import Direction, Sector
 from mud.registry import area_registry, mob_registry, obj_registry, room_registry
 
@@ -122,6 +123,10 @@ def object_to_dict(obj) -> dict:
 def convert_area(path: str) -> dict:
     clear_registries()
     area = load_area_file(path)
+    reset_errors = validate_resets(area)
+    if reset_errors:
+        joined = "; ".join(reset_errors)
+        raise ValueError(f"Reset validation failed: {joined}")
     rooms = [room_to_dict(r) for r in room_registry.values() if r.area is area]
     mobiles = [mob_to_dict(m) for m in mob_registry.values() if m.area is area]
     objects = [object_to_dict(o) for o in obj_registry.values() if o.area is area]

--- a/tests/test_area_loader.py
+++ b/tests/test_area_loader.py
@@ -5,6 +5,7 @@ import pytest
 
 from mud.loaders import load_area_file
 from mud.loaders.json_loader import load_area_from_json
+from mud.loaders.reset_loader import validate_resets
 from mud.models.constants import RoomFlag
 from mud.registry import area_registry, room_registry
 from mud.scripts.convert_are_to_json import clear_registries, convert_area
@@ -183,3 +184,10 @@ def test_json_loader_applies_defaults_and_law_flag(tmp_path):
 
     area_registry.clear()
     room_registry.clear()
+
+
+def test_midgaard_reset_validation():
+    clear_registries()
+    area = load_area_file("area/midgaard.are")
+    errors = validate_resets(area)
+    assert errors == []

--- a/tests/test_help_system.py
+++ b/tests/test_help_system.py
@@ -82,3 +82,19 @@ def test_help_overlong_request_rebukes_and_skips_logging(monkeypatch, tmp_path, 
     assert any("Excessive help request length" in record.message for record in caplog.records)
     log_path = Path("log") / OHELPS_FILE
     assert not log_path.exists()
+
+
+def test_help_generates_command_topic_when_missing():
+    load_help_file("data/help.json")
+    ch = Character(name="Tester")
+    result = process_command(ch, "help unalias")
+    assert "Command: unalias" in result
+    assert "Minimum position" in result
+
+
+def test_help_missing_topic_suggests_commands():
+    load_help_file("data/help.json")
+    ch = Character(name="Tester")
+    result = process_command(ch, "help unknown")
+    assert "Try:" in result
+    assert "unban" in result or "unalias" in result

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -1,0 +1,51 @@
+from mud.commands.dispatcher import process_command
+from mud.models.character import Character, character_registry
+from mud.models.constants import Direction, Position
+from mud.models.room import Exit, Room
+from mud.world import create_test_character, initialize_world
+from mud.world.movement import move_character
+
+
+def _build_rooms() -> tuple[Room, Room]:
+    start = Room(vnum=2000, name="Start")
+    target = Room(vnum=2001, name="Target")
+    start.exits[Direction.NORTH.value] = Exit(to_room=target, keyword="gate")
+    return start, target
+
+
+def test_follower_cascade():
+    start, target = _build_rooms()
+
+    leader = Character(name="Leader", is_npc=False, move=20)
+    follower = Character(name="Guard", is_npc=True, move=20)
+    follower.master = leader
+    follower.position = Position.STANDING
+
+    start.add_character(leader)
+    start.add_character(follower)
+
+    result = move_character(leader, "north")
+
+    assert "You walk north" in result
+    assert leader.room is target
+    assert follower.room is target
+    assert any(msg.startswith("You follow") for msg in follower.messages)
+
+
+def test_followers_enter_portal(portal_factory):
+    try:
+        initialize_world("area/area.lst")
+        leader = create_test_character("Leader", 3001)
+        follower = create_test_character("Scout", 3001)
+        follower.master = leader
+        follower.position = Position.STANDING
+
+        portal_factory(3001, to_vnum=3054, closed=False)
+
+        out = process_command(leader, "enter portal")
+
+        assert "arrive" in out
+        assert follower.room is not None and follower.room.vnum == 3054
+        assert any("follow" in msg.lower() for msg in follower.messages)
+    finally:
+        character_registry.clear()

--- a/tests/test_resets.py
+++ b/tests/test_resets.py
@@ -1,0 +1,26 @@
+from mud.game_loop import game_tick
+from mud.registry import room_registry
+from mud.spawning.templates import MobInstance
+from mud.world import initialize_world
+
+
+def test_execution_cycle(monkeypatch):
+    initialize_world("area/area.lst")
+
+    bakery = room_registry[3001]
+    donation = room_registry[3054]
+    area = bakery.area
+    assert area is not None
+
+    bakery.people = [p for p in bakery.people if not isinstance(p, MobInstance)]
+    donation.contents.clear()
+
+    area.age = 2
+    area.empty = False
+
+    monkeypatch.setattr("mud.game_loop._area_counter", 1)
+
+    game_tick()
+
+    assert any(isinstance(p, MobInstance) for p in bakery.people)
+    assert any(getattr(getattr(o, "prototype", None), "vnum", None) == 3010 for o in donation.contents)


### PR DESCRIPTION
## Summary
- harden reset validation to track LastMob/LastObj context and surface cross-area issues during conversion
- cascade followers (including portals) through shared helpers while enriching help command fallbacks
- add focused tests covering reset validation/execution, movement followers, and help command suggestions

## Testing
- PYTHONPATH=. pytest tests/test_area_loader.py::test_midgaard_reset_validation
- PYTHONPATH=. pytest tests/test_movement.py
- PYTHONPATH=. pytest tests/test_help_system.py
- PYTHONPATH=. pytest tests/test_resets.py

------
https://chatgpt.com/codex/tasks/task_b_68db3814bacc83208c5f5e857a1f5e24