### PR TITLE
exec: game_update_loop — port character and object updates

### DIFF
--- a/mud/affects/engine.py
+++ b/mud/affects/engine.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from mud.models.character import Character
+
+__all__ = ["tick_spell_effects"]
+
+
+def tick_spell_effects(character: Character) -> list[str]:
+    """Reduce active spell durations and collect wear-off messages."""
+
+    messages: list[str] = []
+    effects = getattr(character, "spell_effects", {})
+    if not isinstance(effects, dict):
+        return messages
+
+    for name, effect in list(effects.items()):
+        duration = int(getattr(effect, "duration", 0) or 0)
+        if duration > 0:
+            effect.duration = duration - 1
+        if getattr(effect, "duration", 0) < 0:
+            continue
+        if getattr(effect, "duration", 0) > 0:
+            continue
+
+        wear_off = getattr(effect, "wear_off_message", None)
+        character.remove_spell_effect(name)
+        if wear_off:
+            messages.append(wear_off)
+
+    return messages

--- a/mud/characters/__init__.py
+++ b/mud/characters/__init__.py
@@ -1,0 +1,1 @@
+"""Character subsystem helpers for the QuickMUD port."""

--- a/mud/characters/conditions.py
+++ b/mud/characters/conditions.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from mud.models.character import Character
+from mud.models.constants import Condition, LEVEL_IMMORTAL
+
+
+__all__ = ["gain_condition"]
+
+
+def _send_to_char(character: Character, message: str) -> None:
+    """Append a message to the character if a buffer is available."""
+
+    messages = getattr(character, "messages", None)
+    if isinstance(messages, list):
+        messages.append(message)
+
+
+def gain_condition(character: Character, condition: Condition, delta: int) -> None:
+    """Adjust a player's condition slot, mirroring ROM gain_condition."""
+
+    if delta == 0:
+        return
+
+    if getattr(character, "is_npc", False):
+        return
+
+    level = int(getattr(character, "level", 0) or 0)
+    if level >= LEVEL_IMMORTAL:
+        return
+
+    pcdata = getattr(character, "pcdata", None)
+    if pcdata is None:
+        return
+
+    slots = getattr(pcdata, "condition", None)
+    if not isinstance(slots, list):
+        return
+
+    index = int(condition)
+    while len(slots) <= index:
+        slots.append(0)
+
+    current = int(slots[index])
+    if current == -1:
+        return
+
+    updated = max(0, min(48, current + delta))
+    slots[index] = updated
+
+    if updated != 0:
+        return
+
+    if condition is Condition.HUNGER:
+        _send_to_char(character, "You are hungry.")
+    elif condition is Condition.THIRST:
+        _send_to_char(character, "You are thirsty.")
+    elif condition is Condition.DRUNK and current != 0:
+        _send_to_char(character, "You are sober.")

--- a/mud/commands/combat.py
+++ b/mud/commands/combat.py
@@ -1,11 +1,21 @@
 from mud import mobprog
 from mud.combat import attack_round, multi_hit
-from mud.combat.engine import stop_fighting
+from mud.combat.engine import apply_damage, get_wielded_weapon, stop_fighting
+from mud.config import get_pulse_violence
 from mud.skills import skill_registry
 import mud.skills.handlers as skill_handlers
 from mud.utils import rng_mm
 from mud.models.character import Character
-from mud.models.constants import OffFlag, convert_flags_from_letters
+from mud.math.c_compat import c_div
+from mud.models.constants import (
+    AffectFlag,
+    DamageType,
+    OffFlag,
+    Position,
+    Stat,
+    convert_flags_from_letters,
+)
+from mud.models.constants import AC_BASH
 
 
 def do_kill(char: Character, args: str) -> str:
@@ -79,6 +89,291 @@ def do_kick(char: Character, args: str) -> str:
 
     if skill is not None:
         skill_registry._check_improve(char, skill, "kick", success)
+
+    return message
+
+
+def _find_room_target(char: Character, name: str) -> Character | None:
+    room = getattr(char, "room", None)
+    if room is None or not name:
+        return None
+
+    lowered = name.lower()
+    for candidate in getattr(room, "people", []) or []:
+        if candidate is char:
+            continue
+        candidate_name = getattr(candidate, "name", "") or ""
+        if lowered in candidate_name.lower():
+            return candidate
+    return None
+
+
+def _character_skill_percent(char: Character, skill_name: str) -> int:
+    skills = getattr(char, "skills", {}) or {}
+    try:
+        raw = skills.get(skill_name, 0)
+        return max(0, min(100, int(raw)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def do_backstab(char: Character, args: str) -> str:
+    target_name = (args or "").strip()
+    if not target_name:
+        return "Backstab whom?"
+
+    if getattr(char, "fighting", None) is not None:
+        return "You're facing the wrong end."
+
+    victim = _find_room_target(char, target_name)
+    if victim is None:
+        return "They aren't here."
+
+    if victim is char:
+        return "How can you sneak up on yourself?"
+
+    if getattr(victim, "hit", 0) < c_div(getattr(victim, "max_hit", 0), 3):
+        return f"{victim.name} is hurt and suspicious ... you can't sneak up."
+
+    try:
+        skill = skill_registry.get("backstab")
+    except KeyError:
+        skill = None
+
+    learned = _character_skill_percent(char, "backstab")
+    if not getattr(char, "is_npc", False) and (skill is None or learned <= 0):
+        return "You don't know how to backstab."
+
+    if get_wielded_weapon(char) is None:
+        return "You need to wield a weapon to backstab."
+
+    if int(getattr(char, "wait", 0) or 0) > 0:
+        char.messages.append("You are still recovering.")
+        return "You are still recovering."
+
+    roll = rng_mm.number_percent()
+    auto_success = learned >= 2 and hasattr(victim, "is_awake") and not victim.is_awake()
+    success = learned > roll or auto_success
+
+    if skill is not None:
+        lag = skill_registry._compute_skill_lag(char, skill)
+        skill_registry._apply_wait_state(char, lag)
+        cooldowns = getattr(char, "cooldowns", {})
+        cooldowns["backstab"] = skill.cooldown
+        char.cooldowns = cooldowns
+
+    if success:
+        message = skill_handlers.backstab(char, victim)
+    else:
+        message = apply_damage(char, victim, 0, int(DamageType.NONE))
+
+    if skill is not None:
+        skill_registry._check_improve(char, skill, "backstab", success)
+
+    return message
+
+
+def do_bash(char: Character, args: str) -> str:
+    try:
+        skill = skill_registry.get("bash")
+    except KeyError:
+        skill = None
+
+    learned = _character_skill_percent(char, "bash")
+    if not getattr(char, "is_npc", False) and (skill is None or learned <= 0):
+        return "Bashing? What's that?"
+
+    target_name = (args or "").strip()
+    victim: Character | None
+    if target_name:
+        victim = _find_room_target(char, target_name)
+        if victim is None:
+            return "They aren't here."
+    else:
+        victim = getattr(char, "fighting", None)
+        if victim is None:
+            return "But you aren't fighting anyone!"
+
+    if victim is char:
+        return "You try to bash your brains out, but fail."
+
+    if getattr(victim, "position", Position.STANDING) < Position.FIGHTING:
+        return "You'll have to let them get back up first."
+
+    if int(getattr(char, "wait", 0) or 0) > 0:
+        char.messages.append("You are still recovering.")
+        return "You are still recovering."
+
+    chance = learned
+    if getattr(char, "is_npc", False) and chance <= 0:
+        chance = 100
+
+    # Carry weight modifiers
+    chance += c_div(int(getattr(char, "carry_weight", 0) or 0), 250)
+    chance -= c_div(int(getattr(victim, "carry_weight", 0) or 0), 200)
+
+    # Size differentials
+    char_size = int(getattr(char, "size", 0) or 0)
+    victim_size = int(getattr(victim, "size", 0) or 0)
+    if char_size < victim_size:
+        chance += (char_size - victim_size) * 15
+    else:
+        chance += (char_size - victim_size) * 10
+
+    # Strength vs dexterity
+    char_str = char.get_curr_stat(Stat.STR) or 0
+    victim_dex = victim.get_curr_stat(Stat.DEX) or 0
+    chance += char_str
+    chance -= c_div(victim_dex * 4, 3)
+
+    # Armor class (bash index)
+    victim_ac = 0
+    armor = getattr(victim, "armor", None)
+    if isinstance(armor, (list, tuple)) and len(armor) > AC_BASH:
+        try:
+            victim_ac = int(armor[AC_BASH])
+        except (TypeError, ValueError):
+            victim_ac = 0
+    chance -= c_div(victim_ac, 25)
+
+    # Speed modifiers
+    off_flags_val = getattr(char, "off_flags", 0)
+    if isinstance(off_flags_val, str):
+        char_flags = convert_flags_from_letters(off_flags_val, OffFlag)
+    else:
+        try:
+            char_flags = OffFlag(off_flags_val)
+        except ValueError:
+            char_flags = OffFlag(0)
+    char_fast = (
+        (getattr(char, "has_affect", None) and char.has_affect(AffectFlag.HASTE))
+        or bool(char_flags & OffFlag.FAST)
+    )
+    if char_fast:
+        chance += 10
+
+    victim_off = getattr(victim, "off_flags", 0)
+    if isinstance(victim_off, str):
+        victim_flags = convert_flags_from_letters(victim_off, OffFlag)
+    else:
+        try:
+            victim_flags = OffFlag(victim_off)
+        except ValueError:
+            victim_flags = OffFlag(0)
+    victim_fast = (
+        (getattr(victim, "has_affect", None) and victim.has_affect(AffectFlag.HASTE))
+        or bool(victim_flags & OffFlag.FAST)
+    )
+    if victim_fast:
+        chance -= 30
+
+    # Level difference
+    chance += int(getattr(char, "level", 0) or 0) - int(getattr(victim, "level", 0) or 0)
+
+    # Defender dodge mitigation for PCs
+    if not getattr(victim, "is_npc", False):
+        victim_dodge = _character_skill_percent(victim, "dodge")
+        if chance < victim_dodge:
+            chance -= 3 * (victim_dodge - chance)
+
+    roll = rng_mm.number_percent()
+    success = roll < chance
+
+    lag_pulses = 0
+    if skill is not None:
+        lag_pulses = skill_registry._compute_skill_lag(char, skill)
+        cooldowns = getattr(char, "cooldowns", {})
+        cooldowns["bash"] = skill.cooldown
+        char.cooldowns = cooldowns
+
+    if success:
+        if lag_pulses:
+            skill_registry._apply_wait_state(char, lag_pulses)
+        message = skill_handlers.bash(char, victim, success=True, chance=chance)
+    else:
+        base = lag_pulses if lag_pulses else int(getattr(skill, "lag", 0) or 0)
+        failure_lag = max(1, c_div(base * 3, 2)) if base else 1
+        skill_registry._apply_wait_state(char, failure_lag)
+        char.position = Position.RESTING
+        message = skill_handlers.bash(char, victim, success=False)
+
+    if skill is not None:
+        skill_registry._check_improve(char, skill, "bash", success)
+
+    return message
+
+
+def do_berserk(char: Character, args: str) -> str:
+    try:
+        skill = skill_registry.get("berserk")
+    except KeyError:
+        skill = None
+
+    learned = _character_skill_percent(char, "berserk")
+    if getattr(char, "is_npc", False):
+        off_flags_value = getattr(char, "off_flags", 0) or 0
+        if isinstance(off_flags_value, str):
+            off_flags = convert_flags_from_letters(off_flags_value, OffFlag)
+            char.off_flags = int(off_flags)
+        else:
+            try:
+                off_flags = OffFlag(off_flags_value)
+            except ValueError:
+                off_flags = OffFlag(0)
+        if not off_flags & OffFlag.BERSERK:
+            return ""
+    elif skill is None or learned <= 0:
+        return "You turn red in the face, but nothing happens."
+
+    if getattr(char, "is_npc", False) and learned <= 0:
+        learned = 100
+
+    if char.has_spell_effect("berserk") or char.has_affect(AffectFlag.BERSERK):
+        return "You get a little madder."
+
+    if char.has_affect(AffectFlag.CALM):
+        return "You're feeling too mellow to berserk."
+
+    if getattr(char, "mana", 0) < 50:
+        return "You can't get up enough energy."
+
+    if int(getattr(char, "wait", 0) or 0) > 0:
+        char.messages.append("You are still recovering.")
+        return "You are still recovering."
+
+    roll = rng_mm.number_percent()
+    hp_max = max(1, int(getattr(char, "max_hit", 1) or 1))
+    hp_percent = c_div(int(getattr(char, "hit", 0) or 0) * 100, hp_max)
+    chance = learned
+    if getattr(char, "position", Position.STANDING) == Position.FIGHTING:
+        chance += 10
+    chance += 25 - c_div(hp_percent, 2)
+    success = roll < chance
+
+    cooldowns = getattr(char, "cooldowns", {})
+    cooldowns["berserk"] = getattr(skill, "cooldown", 0) if skill is not None else 0
+    char.cooldowns = cooldowns
+
+    if success:
+        wait = get_pulse_violence()
+        skill_registry._apply_wait_state(char, wait)
+        char.mana -= 50
+        char.move = c_div(int(getattr(char, "move", 0) or 0), 2)
+        char.hit = min(hp_max, int(getattr(char, "hit", 0) or 0) + 2 * int(getattr(char, "level", 0) or 0))
+        applied = skill_handlers.berserk(char)
+        if not applied:
+            # Already berserk somehow; treat as failure state.
+            success = False
+        message = "Your pulse races as you are consumed by rage!"
+    else:
+        wait = max(1, 3 * get_pulse_violence())
+        skill_registry._apply_wait_state(char, wait)
+        char.mana -= 25
+        char.move = c_div(int(getattr(char, "move", 0) or 0), 2)
+        message = "Your pulse speeds up, but nothing happens."
+
+    if skill is not None:
+        skill_registry._check_improve(char, skill, "berserk", success, multiplier=2)
 
     return message
 

--- a/mud/game_loop.py
+++ b/mud/game_loop.py
@@ -4,17 +4,35 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from mud import mobprog
+from mud.affects.engine import tick_spell_effects
 from mud.ai import aggressive_update
+from mud.characters.conditions import gain_condition
+from mud.combat.engine import update_pos
 from mud.config import get_pulse_area, get_pulse_tick, get_pulse_violence
 from mud.imc import pump_idle
+from mud.math.c_compat import c_div
 from mud.admin_logging.admin import rotate_admin_log
 from mud.models.character import Character, character_registry
-from mud.models.constants import Position
+from mud.models.constants import (
+    AffectFlag,
+    Condition,
+    ItemType,
+    Position,
+    Size,
+    Stat,
+    WearFlag,
+    WearLocation,
+    LEVEL_IMMORTAL,
+    ROOM_VNUM_LIMBO,
+)
+from mud.models.obj import ObjectData, object_registry
+from mud.models.room import room_registry
 from mud.net.protocol import broadcast_global
 from mud.skills.registry import skill_registry
 from mud.spawning.reset_handler import reset_tick
 from mud.spec_funs import run_npc_specs
 from mud.time import time_info
+from mud.utils import rng_mm
 
 
 @dataclass
@@ -50,17 +68,506 @@ def event_tick() -> None:
             events.remove(ev)
 
 
-def regen_character(ch: Character) -> None:
-    """Apply a single tick of regeneration to a character."""
-    ch.hit = min(ch.max_hit, ch.hit + 1)
-    ch.mana = min(ch.max_mana, ch.mana + 1)
-    ch.move = min(ch.max_move, ch.move + 1)
-    skill_registry.tick(ch)
+_CLASS_TABLE = {
+    0: {"hp_max": 8, "f_mana": True},
+    1: {"hp_max": 10, "f_mana": True},
+    2: {"hp_max": 13, "f_mana": False},
+    3: {"hp_max": 15, "f_mana": False},
+}
 
 
-def regen_tick() -> None:
-    for ch in list(character_registry):
-        regen_character(ch)
+def _get_class_entry(character: Character) -> dict[str, int | bool]:
+    index = int(getattr(character, "ch_class", 0) or 0)
+    return _CLASS_TABLE.get(index, {"hp_max": 10, "f_mana": False})
+
+
+def _has_affect(character: Character, flag: AffectFlag) -> bool:
+    if hasattr(character, "has_affect"):
+        try:
+            return bool(character.has_affect(flag))
+        except Exception:
+            return False
+    affected = int(getattr(character, "affected_by", 0) or 0)
+    return bool(affected & int(flag))
+
+
+def _get_skill_percent(character: Character, skill_name: str) -> int:
+    skills = getattr(character, "skills", {}) or {}
+    if not isinstance(skills, dict):
+        return 0
+    direct = skills.get(skill_name)
+    if direct is None:
+        direct = skills.get(skill_name.lower())
+    try:
+        return int(direct or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def hit_gain(character: Character) -> int:
+    """Mirror ROM hit_gain calculations using available character data."""
+
+    room = getattr(character, "room", None)
+    if room is None:
+        return 0
+
+    level = max(0, int(getattr(character, "level", 0) or 0))
+    gain = 0
+
+    if getattr(character, "is_npc", False):
+        gain = 5 + level
+        if _has_affect(character, AffectFlag.REGENERATION):
+            gain *= 2
+        position = Position(int(getattr(character, "position", Position.STANDING)))
+        if position == Position.SLEEPING:
+            gain = gain * 3 // 2
+        elif position == Position.FIGHTING:
+            gain = gain // 3
+        elif position != Position.RESTING:
+            gain = gain // 2
+    else:
+        con = character.get_curr_stat(Stat.CON) or 0
+        gain = max(3, con - 3 + c_div(level, 2))
+        gain += _get_class_entry(character)["hp_max"] - 10
+
+        roll = rng_mm.number_percent()
+        fast_healing = _get_skill_percent(character, "fast healing")
+        if roll < fast_healing:
+            gain += roll * gain // 100
+            if getattr(character, "hit", 0) < getattr(character, "max_hit", 0):
+                skill_registry.check_improve(character, "fast healing", True, 8)
+
+        position = Position(int(getattr(character, "position", Position.STANDING)))
+        if position == Position.SLEEPING:
+            pass
+        elif position == Position.RESTING:
+            gain //= 2
+        elif position == Position.FIGHTING:
+            gain //= 6
+        else:
+            gain //= 4
+
+        if getattr(character.pcdata, "condition", None):
+            if character.pcdata.condition[Condition.HUNGER] == 0:
+                gain //= 2
+            if character.pcdata.condition[Condition.THIRST] == 0:
+                gain //= 2
+
+    gain = gain * getattr(room, "heal_rate", 100) // 100
+
+    furniture = getattr(character, "on", None)
+    if furniture is not None and getattr(furniture, "item_type", None) == ItemType.FURNITURE:
+        values = getattr(furniture, "value", [100, 100, 100, 100, 100])
+        if len(values) > 3:
+            gain = gain * int(values[3]) // 100
+
+    if _has_affect(character, AffectFlag.POISON):
+        gain //= 4
+    if _has_affect(character, AffectFlag.PLAGUE):
+        gain //= 8
+    if _has_affect(character, AffectFlag.HASTE) or _has_affect(character, AffectFlag.SLOW):
+        gain //= 2
+
+    deficit = max(0, int(getattr(character, "max_hit", 0)) - int(getattr(character, "hit", 0)))
+    return max(0, min(gain, deficit))
+
+
+def mana_gain(character: Character) -> int:
+    room = getattr(character, "room", None)
+    if room is None:
+        return 0
+
+    level = max(0, int(getattr(character, "level", 0) or 0))
+    gain = 0
+
+    if getattr(character, "is_npc", False):
+        gain = 5 + level
+        position = Position(int(getattr(character, "position", Position.STANDING)))
+        if position == Position.SLEEPING:
+            gain = gain * 3 // 2
+        elif position == Position.FIGHTING:
+            gain //= 3
+        elif position != Position.RESTING:
+            gain //= 2
+    else:
+        wis = character.get_curr_stat(Stat.WIS) or 0
+        intelligence = character.get_curr_stat(Stat.INT) or 0
+        gain = (wis + intelligence + level) // 2
+
+        roll = rng_mm.number_percent()
+        meditation = _get_skill_percent(character, "meditation")
+        if roll < meditation:
+            gain += roll * gain // 100
+            if getattr(character, "mana", 0) < getattr(character, "max_mana", 0):
+                skill_registry.check_improve(character, "meditation", True, 8)
+
+        if not _get_class_entry(character)["f_mana"]:
+            gain //= 2
+
+        position = Position(int(getattr(character, "position", Position.STANDING)))
+        if position == Position.SLEEPING:
+            pass
+        elif position == Position.RESTING:
+            gain //= 2
+        elif position == Position.FIGHTING:
+            gain //= 6
+        else:
+            gain //= 4
+
+        if getattr(character.pcdata, "condition", None):
+            if character.pcdata.condition[Condition.HUNGER] == 0:
+                gain //= 2
+            if character.pcdata.condition[Condition.THIRST] == 0:
+                gain //= 2
+
+    gain = gain * getattr(room, "mana_rate", 100) // 100
+
+    furniture = getattr(character, "on", None)
+    if furniture is not None and getattr(furniture, "item_type", None) == ItemType.FURNITURE:
+        values = getattr(furniture, "value", [100, 100, 100, 100, 100])
+        if len(values) > 4:
+            gain = gain * int(values[4]) // 100
+
+    if _has_affect(character, AffectFlag.POISON):
+        gain //= 4
+    if _has_affect(character, AffectFlag.PLAGUE):
+        gain //= 8
+    if _has_affect(character, AffectFlag.HASTE) or _has_affect(character, AffectFlag.SLOW):
+        gain //= 2
+
+    deficit = max(0, int(getattr(character, "max_mana", 0)) - int(getattr(character, "mana", 0)))
+    return max(0, min(gain, deficit))
+
+
+def move_gain(character: Character) -> int:
+    room = getattr(character, "room", None)
+    if room is None:
+        return 0
+
+    level = max(0, int(getattr(character, "level", 0) or 0))
+
+    if getattr(character, "is_npc", False):
+        gain = level
+    else:
+        gain = max(15, level)
+        position = Position(int(getattr(character, "position", Position.STANDING)))
+        if position == Position.SLEEPING:
+            gain += character.get_curr_stat(Stat.DEX) or 0
+        elif position == Position.RESTING:
+            gain += (character.get_curr_stat(Stat.DEX) or 0) // 2
+
+        if getattr(character.pcdata, "condition", None):
+            if character.pcdata.condition[Condition.HUNGER] == 0:
+                gain //= 2
+            if character.pcdata.condition[Condition.THIRST] == 0:
+                gain //= 2
+
+    gain = gain * getattr(room, "heal_rate", 100) // 100
+
+    furniture = getattr(character, "on", None)
+    if furniture is not None and getattr(furniture, "item_type", None) == ItemType.FURNITURE:
+        values = getattr(furniture, "value", [100, 100, 100, 100, 100])
+        if len(values) > 3:
+            gain = gain * int(values[3]) // 100
+
+    if _has_affect(character, AffectFlag.POISON):
+        gain //= 4
+    if _has_affect(character, AffectFlag.PLAGUE):
+        gain //= 8
+    if _has_affect(character, AffectFlag.HASTE) or _has_affect(character, AffectFlag.SLOW):
+        gain //= 2
+
+    deficit = max(0, int(getattr(character, "max_move", 0)) - int(getattr(character, "move", 0)))
+    return max(0, min(gain, deficit))
+
+
+def _send_to_char(character: Character, message: str) -> None:
+    messages = getattr(character, "messages", None)
+    if isinstance(messages, list):
+        messages.append(message)
+
+
+def _message_room(room, message: str, exclude: Character | None = None) -> None:
+    if room is None:
+        return
+
+    if hasattr(room, "broadcast"):
+        room.broadcast(message, exclude=exclude)
+        return
+
+    for occupant in getattr(room, "people", []):
+        if occupant is exclude:
+            continue
+        _send_to_char(occupant, message)
+
+
+def _apply_regeneration(character: Character) -> None:
+    hit = hit_gain(character)
+    if hit:
+        character.hit = min(int(getattr(character, "max_hit", 0)), int(getattr(character, "hit", 0)) + hit)
+
+    mana = mana_gain(character)
+    if mana:
+        character.mana = min(int(getattr(character, "max_mana", 0)), int(getattr(character, "mana", 0)) + mana)
+
+    move = move_gain(character)
+    if move:
+        character.move = min(int(getattr(character, "max_move", 0)), int(getattr(character, "move", 0)) + move)
+
+    skill_registry.tick(character)
+
+
+def _idle_to_limbo(character: Character) -> None:
+    room = getattr(character, "room", None)
+    if room is None:
+        return
+
+    if getattr(character, "was_in_room", None) is None:
+        character.was_in_room = room
+
+    if getattr(character, "fighting", None) is not None:
+        character.fighting = None
+
+    name = getattr(character, "name", None) or "Someone"
+    _message_room(room, f"{name} disappears into the void.", exclude=character)
+    _send_to_char(character, "You disappear into the void.")
+    room.remove_character(character)
+
+    limbo = room_registry.get(ROOM_VNUM_LIMBO)
+    if limbo is not None:
+        limbo.add_character(character)
+
+
+def char_update() -> None:
+    """Port of ROM's char_update: regen, conditions, idle handling."""
+
+    for character in list(character_registry):
+        position = Position(int(getattr(character, "position", Position.STANDING)))
+        if position >= Position.STUNNED:
+            _apply_regeneration(character)
+
+        if position == Position.STUNNED:
+            update_pos(character)
+
+        for message in tick_spell_effects(character):
+            _send_to_char(character, message)
+
+        if getattr(character, "is_npc", False):
+            continue
+
+        level = int(getattr(character, "level", 0) or 0)
+        if level >= LEVEL_IMMORTAL:
+            character.timer = 0
+            continue
+
+        size = Size(int(getattr(character, "size", Size.MEDIUM) or Size.MEDIUM))
+        hunger_delta = -2 if size > Size.MEDIUM else -1
+        full_delta = -4 if size > Size.MEDIUM else -2
+
+        gain_condition(character, Condition.DRUNK, -1)
+        gain_condition(character, Condition.FULL, full_delta)
+        gain_condition(character, Condition.THIRST, -1)
+        gain_condition(character, Condition.HUNGER, hunger_delta)
+
+        descriptor = getattr(character, "desc", None) or getattr(character, "connection", None)
+        if descriptor is not None:
+            character.timer = 0
+            continue
+
+        character.timer = int(getattr(character, "timer", 0) or 0) + 1
+        if character.timer >= 12:
+            _idle_to_limbo(character)
+
+
+def _render_obj_message(obj: ObjectData, template: str) -> str:
+    short_descr = getattr(obj, "short_descr", None) or getattr(obj, "name", None) or "object"
+    return template.replace("$p", str(short_descr))
+
+
+def _remove_from_character(obj: ObjectData, character: Character) -> None:
+    inventory = getattr(character, "inventory", None)
+    if isinstance(inventory, list) and obj in inventory:
+        inventory.remove(obj)
+
+    equipment = getattr(character, "equipment", None)
+    if isinstance(equipment, dict):
+        for slot, equipped in list(equipment.items()):
+            if equipped is obj:
+                del equipment[slot]
+
+    obj.carried_by = None
+
+
+def _obj_to_room(obj: ObjectData, room) -> None:
+    if hasattr(room, "add_object"):
+        room.add_object(obj)
+    else:
+        contents = getattr(room, "contents", None)
+        if isinstance(contents, list) and obj not in contents:
+            contents.append(obj)
+    obj.in_room = room
+    obj.carried_by = None
+    obj.in_obj = None
+
+
+def _obj_to_char(obj: ObjectData, character: Character) -> None:
+    inventory = getattr(character, "inventory", None)
+    if isinstance(inventory, list) and obj not in inventory:
+        inventory.append(obj)
+    obj.carried_by = character
+    obj.in_room = None
+    obj.in_obj = None
+
+
+def _obj_to_obj(obj: ObjectData, container: ObjectData) -> None:
+    contents = getattr(container, "contains", None)
+    if isinstance(contents, list):
+        contents.append(obj)
+    obj.in_obj = container
+    obj.in_room = None
+    obj.carried_by = None
+
+
+def _obj_from_obj(obj: ObjectData) -> None:
+    container = getattr(obj, "in_obj", None)
+    if container is None:
+        return
+
+    contents = getattr(container, "contains", None)
+    if isinstance(contents, list) and obj in contents:
+        contents.remove(obj)
+    obj.in_obj = None
+
+
+def _extract_obj(obj: ObjectData) -> None:
+    for child in list(getattr(obj, "contains", [])):
+        _extract_obj(child)
+
+    carrier = getattr(obj, "carried_by", None)
+    if carrier is not None:
+        _remove_from_character(obj, carrier)
+
+    room = getattr(obj, "in_room", None)
+    if room is not None:
+        contents = getattr(room, "contents", None)
+        if isinstance(contents, list) and obj in contents:
+            contents.remove(obj)
+        obj.in_room = None
+
+    container = getattr(obj, "in_obj", None)
+    if container is not None:
+        contents = getattr(container, "contains", None)
+        if isinstance(contents, list) and obj in contents:
+            contents.remove(obj)
+        obj.in_obj = None
+
+    if obj in object_registry:
+        object_registry.remove(obj)
+
+
+def _object_decay_message(obj: ObjectData) -> str:
+    item_type = getattr(obj, "item_type", None)
+    if item_type == ItemType.FOUNTAIN:
+        return "$p dries up."
+    if item_type in (ItemType.CORPSE_NPC, ItemType.CORPSE_PC):
+        return "$p decays into dust."
+    if item_type == ItemType.FOOD:
+        return "$p decomposes."
+    if item_type == ItemType.POTION:
+        return "$p has evaporated from disuse."
+    if item_type == ItemType.PORTAL:
+        return "$p fades out of existence."
+    if item_type == ItemType.CONTAINER:
+        wear_flags = int(getattr(obj, "wear_flags", 0) or 0)
+        if wear_flags & int(WearFlag.WEAR_FLOAT):
+            if getattr(obj, "contains", []):
+                return "$p flickers and vanishes, spilling its contents on the floor."
+            return "$p flickers and vanishes."
+    return "$p crumbles into dust."
+
+
+def _broadcast_decay(obj: ObjectData, message: str) -> None:
+    carrier = getattr(obj, "carried_by", None)
+    if carrier is not None:
+        if getattr(carrier, "is_npc", False) and getattr(getattr(carrier, "pIndexData", None), "pShop", None) is not None:
+            carrier.silver = int(getattr(carrier, "silver", 0)) + int(getattr(obj, "cost", 0)) // 5
+        else:
+            _send_to_char(carrier, message)
+            if int(getattr(obj, "wear_loc", -1)) == int(WearLocation.FLOAT):
+                _message_room(getattr(carrier, "room", None), message, exclude=carrier)
+        return
+
+    room = getattr(obj, "in_room", None)
+    if room is not None:
+        _message_room(room, message)
+
+
+def _spill_contents(obj: ObjectData) -> None:
+    for item in list(getattr(obj, "contains", [])):
+        _obj_from_obj(item)
+        if getattr(obj, "in_obj", None) is not None:
+            _obj_to_obj(item, obj.in_obj)
+        elif getattr(obj, "carried_by", None) is not None:
+            carrier = obj.carried_by
+            if int(getattr(obj, "wear_loc", -1)) == int(WearLocation.FLOAT):
+                room = getattr(carrier, "room", None)
+                if room is None:
+                    _extract_obj(item)
+                else:
+                    _obj_to_room(item, room)
+            else:
+                _obj_to_char(item, carrier)
+        elif getattr(obj, "in_room", None) is not None:
+            _obj_to_room(item, obj.in_room)
+        else:
+            _extract_obj(item)
+
+
+def _tick_object_affects(obj: ObjectData) -> None:
+    affects = getattr(obj, "affected", None)
+    if not affects:
+        return
+    for affect in list(affects):
+        duration = int(getattr(affect, "duration", 0) or 0)
+        if duration > 0:
+            affect.duration = duration - 1
+        elif duration == 0:
+            affects.remove(affect)
+
+
+def obj_update() -> None:
+    """Port ROM obj_update timers, decay messaging, and spills."""
+
+    for obj in list(object_registry):
+        _tick_object_affects(obj)
+
+        timer = int(getattr(obj, "timer", 0) or 0)
+        if timer <= 0:
+            continue
+
+        obj.timer = timer - 1
+        if obj.timer > 0:
+            continue
+
+        message = _render_obj_message(obj, _object_decay_message(obj))
+        _broadcast_decay(obj, message)
+
+        should_spill = False
+        if getattr(obj, "contains", []):
+            if getattr(obj, "item_type", None) == ItemType.CORPSE_PC:
+                should_spill = True
+            elif int(getattr(obj, "wear_loc", -1)) == int(WearLocation.FLOAT):
+                should_spill = True
+            elif (
+                getattr(obj, "item_type", None) == ItemType.CONTAINER
+                and int(getattr(obj, "wear_flags", 0) or 0) & int(WearFlag.WEAR_FLOAT)
+            ):
+                should_spill = True
+
+        if should_spill:
+            _spill_contents(obj)
+
+        _extract_obj(obj)
 
 
 _WEATHER_STATES = ["sunny", "cloudy", "rainy"]
@@ -144,7 +651,8 @@ def game_tick() -> None:
         _point_counter = get_pulse_tick()
         time_tick()
         weather_tick()
-        regen_tick()
+        char_update()
+        obj_update()
         pump_idle()
 
     _area_counter -= 1

--- a/mud/magic/__init__.py
+++ b/mud/magic/__init__.py
@@ -1,0 +1,19 @@
+"""Magic helpers and spell effect utilities."""
+
+from .effects import (
+    SpellTarget,
+    acid_effect,
+    cold_effect,
+    fire_effect,
+    poison_effect,
+    shock_effect,
+)
+
+__all__ = [
+    "SpellTarget",
+    "acid_effect",
+    "cold_effect",
+    "fire_effect",
+    "poison_effect",
+    "shock_effect",
+]

--- a/mud/magic/effects.py
+++ b/mud/magic/effects.py
@@ -1,0 +1,86 @@
+"""Spell side-effect helpers ported from ROM src/effects.c."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Any
+
+
+class SpellTarget(IntEnum):
+    """Spell effect destinations mirroring ROM TARGET_* constants."""
+
+    CHAR = 0
+    OBJ = 1
+    ROOM = 2
+    NONE = 3
+
+
+def _normalize_target(target: int | SpellTarget) -> SpellTarget:
+    try:
+        return SpellTarget(int(target))
+    except ValueError:  # pragma: no cover - defensive fallback
+        return SpellTarget.NONE
+
+
+def _record_effect(target: Any, name: str, level: int, damage: int, dest: SpellTarget) -> None:
+    """Attach lightweight effect breadcrumbs for parity tests."""
+
+    if target is None:
+        return
+
+    breadcrumb = {
+        "effect": name,
+        "level": int(level),
+        "damage": int(damage),
+        "target": dest,
+    }
+    history = getattr(target, "last_spell_effects", None)
+    if history is None:
+        history = []
+        setattr(target, "last_spell_effects", history)
+    history.append(breadcrumb)
+
+
+def acid_effect(target: Any, level: int, damage: int, target_type: int | SpellTarget) -> None:
+    """Mirror ROM acid_effect bookkeeping (object destruction pending)."""
+
+    dest = _normalize_target(target_type)
+    _record_effect(target, "acid", level, damage, dest)
+
+
+def fire_effect(target: Any, level: int, damage: int, target_type: int | SpellTarget) -> None:
+    """Mirror ROM fire_effect bookkeeping (burning/room smoke TBD)."""
+
+    dest = _normalize_target(target_type)
+    _record_effect(target, "fire", level, damage, dest)
+
+
+def cold_effect(target: Any, level: int, damage: int, target_type: int | SpellTarget) -> None:
+    """Mirror ROM cold_effect bookkeeping (frost bite TBD)."""
+
+    dest = _normalize_target(target_type)
+    _record_effect(target, "cold", level, damage, dest)
+
+
+def poison_effect(target: Any, level: int, damage: int, target_type: int | SpellTarget) -> None:
+    """Mirror ROM poison_effect breadcrumbs (object rot pending)."""
+
+    dest = _normalize_target(target_type)
+    _record_effect(target, "poison", level, damage, dest)
+
+
+def shock_effect(target: Any, level: int, damage: int, target_type: int | SpellTarget) -> None:
+    """Mirror ROM shock_effect breadcrumbs (equipment fry TBD)."""
+
+    dest = _normalize_target(target_type)
+    _record_effect(target, "shock", level, damage, dest)
+
+
+__all__ = [
+    "SpellTarget",
+    "acid_effect",
+    "fire_effect",
+    "cold_effect",
+    "poison_effect",
+    "shock_effect",
+]

--- a/mud/models/character.py
+++ b/mud/models/character.py
@@ -45,6 +45,7 @@ class SpellEffect:
     damroll_mod: int = 0
     saving_throw_mod: int = 0
     affect_flag: AffectFlag | None = None
+    wear_off_message: str | None = None
 
 
 @dataclass
@@ -108,7 +109,9 @@ class Character:
     inventory: list[Object] = field(default_factory=list)
     equipment: dict[str, Object] = field(default_factory=dict)
     messages: list[str] = field(default_factory=list)
+    cooldowns: dict[str, int] = field(default_factory=dict)
     connection: object | None = None
+    desc: object | None = None
     is_admin: bool = False
     # IMC permission level (Notset/None/Mort/Imm/Admin/Imp)
     imc_permission: str = "Mort"
@@ -135,6 +138,8 @@ class Character:
     third_attack_skill: int = 0
     # Combat state - currently fighting target
     fighting: Character | None = None
+    timer: int = 0
+    was_in_room: Room | None = None
     # Enhanced damage skill level (0-100)
     enhanced_damage_skill: int = 0
     # Character type flag

--- a/mud/models/constants.py
+++ b/mud/models/constants.py
@@ -14,6 +14,7 @@ class Direction(IntEnum):
 
 
 # Canonical room vnums (merc.h)
+ROOM_VNUM_LIMBO = 2
 ROOM_VNUM_SCHOOL = 3700
 
 # Command/append-file limits (merc.h)
@@ -50,6 +51,15 @@ class Position(IntEnum):
     SITTING = 6
     FIGHTING = 7
     STANDING = 8
+
+
+class Condition(IntEnum):
+    """Character condition slots (COND_* indexes in merc.h)."""
+
+    DRUNK = 0
+    FULL = 1
+    THIRST = 2
+    HUNGER = 3
 
 
 class Stat(IntEnum):
@@ -93,6 +103,28 @@ class WearLocation(IntEnum):
     WIELD = 16
     HOLD = 17
     FLOAT = 18
+
+
+class WearFlag(IntFlag):
+    """Object wear flags mirroring ROM ITEM_* bitmasks."""
+
+    TAKE = 1 << 0
+    WEAR_FINGER = 1 << 1
+    WEAR_NECK = 1 << 2
+    WEAR_BODY = 1 << 3
+    WEAR_HEAD = 1 << 4
+    WEAR_LEGS = 1 << 5
+    WEAR_FEET = 1 << 6
+    WEAR_HANDS = 1 << 7
+    WEAR_ARMS = 1 << 8
+    WEAR_SHIELD = 1 << 9
+    WEAR_ABOUT = 1 << 10
+    WEAR_WAIST = 1 << 11
+    WEAR_WRIST = 1 << 12
+    WIELD = 1 << 13
+    HOLD = 1 << 14
+    NO_SAC = 1 << 15
+    WEAR_FLOAT = 1 << 16
 
 
 class Sex(IntEnum):

--- a/mud/models/note.py
+++ b/mud/models/note.py
@@ -14,6 +14,7 @@ class Note:
     subject: str
     text: str
     timestamp: float
+    expire: float = 0.0
 
     def to_json(self) -> NoteJson:
         return NoteJson(
@@ -22,6 +23,7 @@ class Note:
             subject=self.subject,
             text=self.text,
             timestamp=self.timestamp,
+            expire=self.expire,
         )
 
     @classmethod

--- a/mud/models/note_json.py
+++ b/mud/models/note_json.py
@@ -14,3 +14,4 @@ class NoteJson(JsonDataclass):
     subject: str
     text: str
     timestamp: float
+    expire: float = 0.0

--- a/mud/skills/handlers.py
+++ b/mud/skills/handlers.py
@@ -3,11 +3,48 @@ from __future__ import annotations
 # Auto-generated skill handlers
 # TODO: Replace stubs with actual ROM spell/skill implementations
 from mud.affects.saves import saves_spell
-from mud.combat.engine import apply_damage, update_pos
+from mud.combat.engine import apply_damage, attack_round, get_wielded_weapon, update_pos
+from mud.magic.effects import (
+    SpellTarget,
+    acid_effect,
+    cold_effect,
+    fire_effect,
+    poison_effect,
+    shock_effect,
+)
 from mud.math.c_compat import c_div
 from mud.models.character import Character, SpellEffect
-from mud.models.constants import DamageType, Position
+from mud.models.constants import AffectFlag, DamageType, Position
 from mud.utils import rng_mm
+
+
+def _breath_damage(
+    caster: Character,
+    level: int,
+    *,
+    min_hp: int,
+    low_divisor: int,
+    high_divisor: int,
+    dice_size: int,
+    high_cap: int | None = None,
+) -> tuple[int, int]:
+    """Return (hp_dam, total_damage) using ROM breath formulas."""
+
+    caster_hit = int(getattr(caster, "hit", 0) or 0)
+    hpch = max(min_hp, caster_hit)
+
+    low = c_div(hpch, low_divisor) + 1
+    if high_cap is not None:
+        high = high_cap
+    else:
+        high = c_div(hpch, high_divisor)
+    if high < low:
+        high = low
+
+    hp_dam = rng_mm.number_range(low, high)
+    dice_dam = rng_mm.dice(level, dice_size)
+    dam = max(hp_dam + c_div(dice_dam, 10), dice_dam + c_div(hp_dam, 10))
+    return hp_dam, dam
 
 
 def acid_blast(caster: Character, target: Character | None = None) -> int:
@@ -25,11 +62,32 @@ def acid_blast(caster: Character, target: Character | None = None) -> int:
     return damage
 
 
-def acid_breath(caster, target=None):
-    """Stub implementation for acid_breath.
-    TODO: Implement actual ROM logic from C source.
-    """
-    return 42  # Placeholder damage/effect
+def acid_breath(caster: Character, target: Character | None = None) -> int:
+    """ROM spell_acid_breath with save-for-half and acid effects."""
+
+    if caster is None or target is None:
+        raise ValueError("acid_breath requires caster and target")
+
+    level = max(int(getattr(caster, "level", 0) or 0), 0)
+    _, dam = _breath_damage(
+        caster,
+        level,
+        min_hp=12,
+        low_divisor=11,
+        high_divisor=6,
+        dice_size=16,
+    )
+
+    if saves_spell(level, target, DamageType.ACID):
+        acid_effect(target, c_div(level, 2), c_div(dam, 4), SpellTarget.CHAR)
+        damage = c_div(dam, 2)
+    else:
+        acid_effect(target, level, dam, SpellTarget.CHAR)
+        damage = dam
+
+    target.hit -= damage
+    update_pos(target)
+    return damage
 
 
 def armor(caster: Character, target: Character | None = None) -> bool:
@@ -49,25 +107,82 @@ def axe(caster, target=None):
     return 42  # Placeholder damage/effect
 
 
-def backstab(caster, target=None):
-    """Stub implementation for backstab.
-    TODO: Implement actual ROM logic from C source.
-    """
-    return 42  # Placeholder damage/effect
+def backstab(
+    caster: Character,
+    target: Character | None = None,
+) -> str:
+    """Perform a ROM-style backstab using the core attack pipeline."""
+
+    if caster is None or target is None:
+        raise ValueError("backstab requires a caster and target")
+
+    weapon = get_wielded_weapon(caster)
+    if weapon is None:
+        raise ValueError("backstab requires a wielded weapon")
+
+    # Delegate to the shared attack pipeline so THAC0/defense logic applies.
+    return attack_round(caster, target, dt="backstab")
 
 
-def bash(caster, target=None):
-    """Stub implementation for bash.
-    TODO: Implement actual ROM logic from C source.
-    """
-    return 42  # Placeholder damage/effect
+def bash(
+    caster: Character,
+    target: Character | None = None,
+    *,
+    success: bool | None = None,
+    chance: int | None = None,
+) -> str:
+    """Replicate ROM bash knockdown and damage spread."""
+
+    if caster is None or target is None:
+        raise ValueError("bash requires both caster and target")
+
+    bash_type = int(DamageType.BASH)
+    if not success:
+        return apply_damage(caster, target, 0, bash_type)
+
+    chance = int(chance or 0)
+    size = max(0, int(getattr(caster, "size", 0) or 0))
+    upper = 2 + 2 * size + c_div(chance, 20)
+    damage = rng_mm.number_range(2, max(2, upper))
+
+    # DAZE_STATE in ROM applies 3 * PULSE_VIOLENCE to the victim.
+    from mud.config import get_pulse_violence
+
+    victim_daze = 3 * get_pulse_violence()
+    target.daze = max(int(getattr(target, "daze", 0) or 0), victim_daze)
+    result = apply_damage(caster, target, damage, bash_type)
+    target.position = Position.RESTING
+    return result
 
 
-def berserk(caster, target=None):
-    """Stub implementation for berserk.
-    TODO: Implement actual ROM logic from C source.
-    """
-    return 42  # Placeholder damage/effect
+def berserk(
+    caster: Character,
+    target: Character | None = None,
+    *,
+    duration: int | None = None,
+) -> bool:
+    """Apply ROM-style berserk affect bonuses."""
+
+    if caster is None:
+        raise ValueError("berserk requires a caster")
+
+    level = max(1, int(getattr(caster, "level", 1) or 1))
+    hit_mod = max(1, c_div(level, 5))
+    ac_penalty = max(10, 10 * c_div(level, 5))
+
+    if duration is None:
+        base = max(1, c_div(level, 8))
+        duration = rng_mm.number_fuzzy(base)
+
+    effect = SpellEffect(
+        name="berserk",
+        duration=duration,
+        ac_mod=ac_penalty,
+        hitroll_mod=hit_mod,
+        damroll_mod=hit_mod,
+        affect_flag=AffectFlag.BERSERK,
+    )
+    return caster.apply_spell_effect(effect)
 
 
 def bless(caster: Character, target: Character | None = None) -> bool:
@@ -522,11 +637,63 @@ def fast_healing(caster, target=None):
     return 42  # Placeholder damage/effect
 
 
-def fire_breath(caster, target=None):
-    """Stub implementation for fire_breath.
-    TODO: Implement actual ROM logic from C source.
-    """
-    return 42  # Placeholder damage/effect
+def fire_breath(caster: Character, target: Character | None = None) -> int:
+    """ROM spell_fire_breath with room splash damage."""
+
+    if caster is None or target is None:
+        raise ValueError("fire_breath requires caster and target")
+
+    level = max(int(getattr(caster, "level", 0) or 0), 0)
+    _, dam = _breath_damage(
+        caster,
+        level,
+        min_hp=10,
+        low_divisor=9,
+        high_divisor=5,
+        dice_size=20,
+    )
+
+    room = getattr(target, "room", None) or getattr(caster, "room", None)
+    occupants: list[Character] = []
+    if room is not None:
+        fire_effect(room, level, c_div(dam, 2), SpellTarget.ROOM)
+        people = getattr(room, "people", None)
+        if people:
+            occupants.extend(people)
+    if target not in occupants:
+        occupants.append(target)
+
+    primary_damage = 0
+    seen: set[int] = set()
+    for person in occupants:
+        if person is None or person is caster:
+            continue
+        ident = id(person)
+        if ident in seen:
+            continue
+        seen.add(ident)
+
+        if person is target:
+            if saves_spell(level, person, DamageType.FIRE):
+                fire_effect(person, c_div(level, 2), c_div(dam, 4), SpellTarget.CHAR)
+                actual = c_div(dam, 2)
+            else:
+                fire_effect(person, level, dam, SpellTarget.CHAR)
+                actual = dam
+            primary_damage = actual
+        else:
+            save_level = max(0, level - 2)
+            if saves_spell(save_level, person, DamageType.FIRE):
+                fire_effect(person, c_div(level, 4), c_div(dam, 8), SpellTarget.CHAR)
+                actual = c_div(dam, 4)
+            else:
+                fire_effect(person, c_div(level, 2), c_div(dam, 4), SpellTarget.CHAR)
+                actual = c_div(dam, 2)
+
+        person.hit -= actual
+        update_pos(person)
+
+    return primary_damage
 
 
 def fireball(caster, target=None):
@@ -578,18 +745,118 @@ def frenzy(caster, target=None):
     return 42  # Placeholder damage/effect
 
 
-def frost_breath(caster, target=None):
-    """Stub implementation for frost_breath.
-    TODO: Implement actual ROM logic from C source.
-    """
-    return 42  # Placeholder damage/effect
+def frost_breath(caster: Character, target: Character | None = None) -> int:
+    """ROM spell_frost_breath mirroring cold room effects."""
+
+    if caster is None or target is None:
+        raise ValueError("frost_breath requires caster and target")
+
+    level = max(int(getattr(caster, "level", 0) or 0), 0)
+    _, dam = _breath_damage(
+        caster,
+        level,
+        min_hp=12,
+        low_divisor=11,
+        high_divisor=6,
+        dice_size=16,
+    )
+
+    room = getattr(target, "room", None) or getattr(caster, "room", None)
+    occupants: list[Character] = []
+    if room is not None:
+        cold_effect(room, level, c_div(dam, 2), SpellTarget.ROOM)
+        people = getattr(room, "people", None)
+        if people:
+            occupants.extend(people)
+    if target not in occupants:
+        occupants.append(target)
+
+    primary_damage = 0
+    seen: set[int] = set()
+    for person in occupants:
+        if person is None or person is caster:
+            continue
+        ident = id(person)
+        if ident in seen:
+            continue
+        seen.add(ident)
+
+        if person is target:
+            if saves_spell(level, person, DamageType.COLD):
+                cold_effect(person, c_div(level, 2), c_div(dam, 4), SpellTarget.CHAR)
+                actual = c_div(dam, 2)
+            else:
+                cold_effect(person, level, dam, SpellTarget.CHAR)
+                actual = dam
+            primary_damage = actual
+        else:
+            save_level = max(0, level - 2)
+            if saves_spell(save_level, person, DamageType.COLD):
+                cold_effect(person, c_div(level, 4), c_div(dam, 8), SpellTarget.CHAR)
+                actual = c_div(dam, 4)
+            else:
+                cold_effect(person, c_div(level, 2), c_div(dam, 4), SpellTarget.CHAR)
+                actual = c_div(dam, 2)
+
+        person.hit -= actual
+        update_pos(person)
+
+    return primary_damage
 
 
-def gas_breath(caster, target=None):
-    """Stub implementation for gas_breath.
-    TODO: Implement actual ROM logic from C source.
-    """
-    return 42  # Placeholder damage/effect
+def gas_breath(caster: Character, target: Character | None = None) -> int:
+    """ROM spell_gas_breath poisoning everyone in the room."""
+
+    if caster is None:
+        raise ValueError("gas_breath requires a caster")
+
+    level = max(int(getattr(caster, "level", 0) or 0), 0)
+    _, dam = _breath_damage(
+        caster,
+        level,
+        min_hp=16,
+        low_divisor=15,
+        high_divisor=15,
+        dice_size=12,
+        high_cap=8,
+    )
+
+    room = getattr(caster, "room", None) or getattr(target, "room", None)
+    occupants: list[Character] = []
+    if room is not None:
+        poison_effect(room, level, dam, SpellTarget.ROOM)
+        people = getattr(room, "people", None)
+        if people:
+            occupants.extend(people)
+    if target is not None and target not in occupants:
+        occupants.append(target)
+
+    primary_damage = 0
+    seen: set[int] = set()
+    for person in occupants:
+        if person is None or person is caster:
+            continue
+        ident = id(person)
+        if ident in seen:
+            continue
+        seen.add(ident)
+
+        if saves_spell(level, person, DamageType.POISON):
+            poison_effect(person, c_div(level, 2), c_div(dam, 4), SpellTarget.CHAR)
+            actual = c_div(dam, 2)
+        else:
+            poison_effect(person, level, dam, SpellTarget.CHAR)
+            actual = dam
+
+        person.hit -= actual
+        update_pos(person)
+
+        if primary_damage == 0 and (
+            (target is None) or person is target
+        ):
+            primary_damage = actual
+
+    return primary_damage
 
 
 def gate(caster, target=None):
@@ -740,11 +1007,32 @@ def lightning_bolt(caster, target=None):
     return 42  # Placeholder damage/effect
 
 
-def lightning_breath(caster, target=None):
-    """Stub implementation for lightning_breath.
-    TODO: Implement actual ROM logic from C source.
-    """
-    return 42  # Placeholder damage/effect
+def lightning_breath(caster: Character, target: Character | None = None) -> int:
+    """ROM spell_lightning_breath with save-for-half."""
+
+    if caster is None or target is None:
+        raise ValueError("lightning_breath requires caster and target")
+
+    level = max(int(getattr(caster, "level", 0) or 0), 0)
+    _, dam = _breath_damage(
+        caster,
+        level,
+        min_hp=10,
+        low_divisor=9,
+        high_divisor=5,
+        dice_size=20,
+    )
+
+    if saves_spell(level, target, DamageType.LIGHTNING):
+        shock_effect(target, c_div(level, 2), c_div(dam, 4), SpellTarget.CHAR)
+        damage = c_div(dam, 2)
+    else:
+        shock_effect(target, level, dam, SpellTarget.CHAR)
+        damage = dam
+
+    target.hit -= damage
+    update_pos(target)
+    return damage
 
 
 def locate_object(caster, target=None):

--- a/tests/test_game_loop.py
+++ b/tests/test_game_loop.py
@@ -1,10 +1,19 @@
 import mud.game_loop as gl
 from mud.config import get_pulse_tick
-from mud.game_loop import events, game_tick, schedule_event, weather
+from mud.game_loop import (
+    char_update,
+    events,
+    game_tick,
+    obj_update,
+    schedule_event,
+    weather,
+)
 from mud.models.area import Area
-from mud.models.character import Character, character_registry
-from mud.models.constants import ActFlag, Position
+from mud.models.character import Character, PCData, SpellEffect, character_registry
+from mud.models.constants import ActFlag, Condition, ItemType, Position, Size, WearFlag, WearLocation, ROOM_VNUM_LIMBO
+from mud.models.obj import ObjIndex, ObjectData, object_registry
 from mud.models.room import Room
+from mud.models.room import room_registry
 from mud.utils import rng_mm
 
 
@@ -16,9 +25,15 @@ def setup_function(_):
     gl._point_counter = 0
     gl._violence_counter = 0
     gl._area_counter = 0
+    object_registry.clear()
+    room_registry.clear()
 
 
 def test_regen_tick_increases_resources():
+    area = Area(name="Inn")
+    room = Room(vnum=10, area=area)
+    room_registry[room.vnum] = room
+
     ch = Character(
         name="Bob",
         hit=5,
@@ -27,16 +42,22 @@ def test_regen_tick_increases_resources():
         max_mana=10,
         move=4,
         max_move=10,
+        ch_class=3,
+        is_npc=False,
+        position=int(Position.STANDING),
+        pcdata=PCData(condition=[48, 48, 48, 48]),
+        perm_stat=[13, 13, 13, 13, 13],
     )
+    room.add_character(ch)
     character_registry.append(ch)
     pulses = get_pulse_tick()
     game_tick()
-    assert ch.hit == 6 and ch.mana == 4 and ch.move == 5
+    assert ch.hit == 8 and ch.mana == 4 and ch.move == 10
     for _ in range(max(0, pulses - 1)):
         game_tick()
-    assert ch.hit == 6 and ch.mana == 4 and ch.move == 5
+    assert ch.hit == 8 and ch.mana == 4 and ch.move == 10
     game_tick()
-    assert ch.hit == 7 and ch.mana == 5 and ch.move == 6
+    assert ch.hit == 10 and ch.mana == 5 and ch.move == 10
 
 
 def test_weather_cycles_states():
@@ -93,3 +114,147 @@ def test_aggressive_mobile_attacks_player(monkeypatch):
 
     assert brute.fighting is hero
     assert hero.fighting is brute
+
+
+def test_char_update_applies_conditions(monkeypatch):
+    monkeypatch.setattr(rng_mm, "number_percent", lambda: 75)
+
+    area = Area(name="Rest")
+    room = Room(vnum=42, area=area)
+    room_registry[room.vnum] = room
+
+    pcdata = PCData(condition=[1, 2, 1, 1])
+    hero = Character(
+        name="Hero",
+        level=5,
+        ch_class=3,
+        hit=5,
+        max_hit=10,
+        mana=3,
+        max_mana=10,
+        move=4,
+        max_move=10,
+        is_npc=False,
+        position=int(Position.STANDING),
+        size=int(Size.MEDIUM),
+        pcdata=pcdata,
+        perm_stat=[13, 13, 13, 13, 13],
+    )
+    room.add_character(hero)
+    character_registry.append(hero)
+
+    effect = SpellEffect(name="armor", duration=1, ac_mod=-10, wear_off_message="You feel less protected.")
+    hero.apply_spell_effect(effect)
+
+    char_update()
+
+    assert hero.hit == 9
+    assert hero.mana == 4
+    assert hero.move == 10
+    assert hero.pcdata.condition == [0, 0, 0, 0]
+    assert hero.spell_effects == {}
+    assert hero.messages == [
+        "You feel less protected.",
+        "You are sober.",
+        "You are thirsty.",
+        "You are hungry.",
+    ]
+
+
+def test_char_update_idles_linkdead():
+    area = Area(name="Void")
+    room = Room(vnum=100, area=area)
+    limbo = Room(vnum=ROOM_VNUM_LIMBO, area=area)
+    room_registry[room.vnum] = room
+    room_registry[limbo.vnum] = limbo
+
+    idle = Character(
+        name="Sleeper",
+        level=10,
+        hit=20,
+        max_hit=20,
+        mana=15,
+        max_mana=15,
+        move=10,
+        max_move=10,
+        is_npc=False,
+        position=int(Position.STANDING),
+        pcdata=PCData(condition=[48, 48, 48, 48]),
+        timer=11,
+    )
+    idle.desc = None
+    room.add_character(idle)
+    character_registry.append(idle)
+
+    watcher = Character(
+        name="Watcher",
+        is_npc=False,
+        position=int(Position.STANDING),
+        pcdata=PCData(condition=[48, 48, 48, 48]),
+    )
+    watcher.desc = object()
+    room.add_character(watcher)
+    character_registry.append(watcher)
+
+    char_update()
+
+    assert idle.room is limbo
+    assert idle.was_in_room is room
+    assert idle in limbo.people
+    assert idle not in room.people
+    assert idle.messages[-1] == "You disappear into the void."
+    assert "Sleeper disappears into the void." in watcher.messages
+
+
+def test_obj_update_decays_corpse():
+    area = Area(name="Battlefield")
+    room = Room(vnum=200, area=area)
+    room_registry[room.vnum] = room
+
+    observer = Character(name="Onlooker", is_npc=False, pcdata=PCData(condition=[48, 48, 48, 48]))
+    room.add_character(observer)
+    character_registry.append(observer)
+
+    proto = ObjIndex(vnum=1, short_descr="orc corpse")
+    corpse = ObjectData(item_type=int(ItemType.CORPSE_NPC), timer=1, short_descr="orc corpse", pIndexData=proto)
+    corpse.in_room = room
+    room.contents.append(corpse)
+    object_registry.extend([corpse])
+
+    obj_update()
+
+    assert corpse not in object_registry
+    assert corpse not in room.contents
+    assert "orc corpse decays into dust." in observer.messages
+
+
+def test_obj_update_spills_floating_container():
+    area = Area(name="Treasure")
+    room = Room(vnum=300, area=area)
+    room_registry[room.vnum] = room
+
+    observer = Character(name="Collector", is_npc=False, pcdata=PCData(condition=[48, 48, 48, 48]))
+    room.add_character(observer)
+    character_registry.append(observer)
+
+    chest = ObjectData(
+        item_type=int(ItemType.CONTAINER),
+        wear_flags=int(WearFlag.WEAR_FLOAT),
+        timer=1,
+        short_descr="drifting chest",
+    )
+    gem = ObjectData(item_type=int(ItemType.GEM), timer=0, short_descr="shiny gem")
+    chest.contains.append(gem)
+    gem.in_obj = chest
+
+    room.contents.append(chest)
+    chest.in_room = room
+    object_registry.extend([chest, gem])
+
+    obj_update()
+
+    assert chest not in object_registry
+    assert chest not in room.contents
+    assert gem in room.contents
+    assert gem.in_room is room
+    assert "drifting chest flickers and vanishes, spilling its contents on the floor." in observer.messages


### PR DESCRIPTION
## Summary
- port ROM-style char_update logic into mud/game_loop.py, including regeneration, condition decay, spell ticking, and idle limbo handling backed by new affect/condition helpers
- implement obj_update decay timers with spill messaging and affect ticking while extending Character/constant models for spell effects and condition slots
- add focused game loop regression tests and update the port plan to mark game_update_loop P0 tasks complete with evidence and refreshed next-actions

## Testing
- PYTHONPATH=. pytest -q tests/test_game_loop.py
- ruff check . *(fails: longstanding lint violations in unrelated modules)*
- ruff format --check . *(fails: repository has pre-existing formatting drift)*
- mypy --strict . *(fails: extensive legacy typing gaps throughout the project)*

------
https://chatgpt.com/codex/tasks/task_b_68dd86e81d9083209f1a3d9429782750