### PR TITLE
Update infrastructure markers and add combat kill counter task

### DIFF
--- a/mud/combat/death.py
+++ b/mud/combat/death.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from mud.characters import is_clan_member
+from mud.models.character import Character, character_registry
+from mud.models.constants import (
+    FormFlag,
+    ItemType,
+    PartFlag,
+    PlayerFlag,
+    Position,
+    OBJ_VNUM_BRAINS,
+    OBJ_VNUM_CORPSE_NPC,
+    OBJ_VNUM_CORPSE_PC,
+    OBJ_VNUM_GUTS,
+    OBJ_VNUM_SEVERED_HEAD,
+    OBJ_VNUM_SLICED_ARM,
+    OBJ_VNUM_SLICED_LEG,
+    OBJ_VNUM_TORN_HEART,
+)
+from mud.models.clans import get_clan_hall_vnum
+from mud.models.races import get_race_by_index
+from mud.models.obj import ObjIndex
+from mud.models.object import Object
+from mud.models.social import expand_placeholders
+from mud.spawning.obj_spawner import spawn_object
+from mud.utils import rng_mm
+from mud.world.world_state import get_room
+
+
+def _clear_player_flag(character: Character, flag: PlayerFlag) -> None:
+    """Clear *flag* from the player's act bitfield."""
+
+    try:
+        character.act = int(getattr(character, "act", 0)) & ~int(flag)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        character.act = 0
+
+
+def _parts_has(victim: Character, flag: PartFlag) -> bool:
+    try:
+        parts = int(getattr(victim, "parts", 0) or 0)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return False
+    return bool(parts & int(flag))
+
+
+def _form_has(victim: Character, flag: FormFlag) -> bool:
+    try:
+        form = int(getattr(victim, "form", 0) or 0)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return False
+    return bool(form & int(flag))
+
+
+def _fallback_gore(
+    vnum: int,
+    *,
+    short_template: str,
+    description_template: str,
+    item_type: ItemType,
+) -> Object:
+    proto = ObjIndex(
+        vnum=vnum,
+        short_descr=short_template,
+        description=description_template,
+    )
+    proto.item_type = int(item_type)
+    obj = Object(instance_id=None, prototype=proto)
+    obj.item_type = int(item_type)
+    return obj
+
+
+def _format_gore_object(
+    obj: Object,
+    name: str,
+    *,
+    short_template: str,
+    description_template: str,
+) -> None:
+    template_short = getattr(obj.prototype, "short_descr", None) or short_template
+    template_desc = getattr(obj.prototype, "description", None) or description_template
+    obj.short_descr = template_short.replace("%s", name)
+    obj.description = template_desc.replace("%s", name)
+
+
+def _normalize_item_type(value: object, default: ItemType) -> int:
+    if isinstance(value, str):
+        mapping = {
+            "food": int(ItemType.FOOD),
+            "trash": int(ItemType.TRASH),
+            "corpse_npc": int(ItemType.CORPSE_NPC),
+            "corpse_pc": int(ItemType.CORPSE_PC),
+        }
+        return mapping.get(value.lower(), int(default))
+    try:
+        return int(value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return int(default)
+
+
+def _spawn_gore(
+    victim: Character,
+    vnum: int,
+    *,
+    short_template: str,
+    description_template: str,
+    default_item_type: ItemType,
+) -> None:
+    room = getattr(victim, "room", None)
+    if room is None:
+        return
+
+    gore = spawn_object(vnum)
+    if gore is None:
+        gore = _fallback_gore(
+            vnum,
+            short_template=short_template,
+            description_template=description_template,
+            item_type=default_item_type,
+        )
+
+    name = getattr(victim, "short_descr", None) or getattr(victim, "name", "someone")
+    _format_gore_object(
+        gore,
+        name,
+        short_template=short_template,
+        description_template=description_template,
+    )
+
+    gore.timer = rng_mm.number_range(4, 7)
+
+    gore.item_type = _normalize_item_type(getattr(gore, "item_type", None), default_item_type)
+
+    if gore.item_type == int(ItemType.FOOD):
+        if _form_has(victim, FormFlag.POISON):
+            values = list(getattr(gore, "value", []) or [])
+            while len(values) <= 3:
+                values.append(0)
+            values[3] = 1
+            gore.value = values
+        elif not _form_has(victim, FormFlag.EDIBLE):
+            gore.item_type = int(ItemType.TRASH)
+
+    room.add_object(gore)
+
+
+def _broadcast_neighbor_cry(victim: Character) -> None:
+    room = getattr(victim, "room", None)
+    if room is None:
+        return
+
+    message = (
+        "You hear something's death cry."
+        if getattr(victim, "is_npc", False)
+        else "You hear someone's death cry."
+    )
+
+    for exit_data in getattr(room, "exits", []) or []:
+        if exit_data is None:
+            continue
+        target = getattr(exit_data, "to_room", None)
+        if target is None or target is room:
+            continue
+        target.broadcast(message)
+
+
+def death_cry(victim: Character) -> None:
+    """Broadcast ROM-style death cry messaging with gore spawns."""
+
+    room = getattr(victim, "room", None)
+    if room is None:
+        return
+
+    message_template = "$n hits the ground ... DEAD."
+    gore_spec: tuple[int, str, str, ItemType] | None = None
+
+    roll = rng_mm.number_bits(4)
+
+    while True:
+        if roll == 0:
+            break
+        if roll == 1:
+            if not getattr(victim, "material", None):
+                message_template = "$n splatters blood on your armor."
+                break
+            roll = 2
+            continue
+        if roll == 2:
+            if _parts_has(victim, PartFlag.GUTS):
+                message_template = "$n spills $s guts all over the floor."
+                gore_spec = (
+                    OBJ_VNUM_GUTS,
+                    "the guts of %s",
+                    "A steaming pile of %s's entrails is lying here.",
+                    ItemType.FOOD,
+                )
+                break
+            roll = 3
+            continue
+        if roll == 3:
+            if _parts_has(victim, PartFlag.HEAD):
+                message_template = "$n's severed head plops on the ground."
+                gore_spec = (
+                    OBJ_VNUM_SEVERED_HEAD,
+                    "the head of %s",
+                    "The severed head of %s is lying here.",
+                    ItemType.TRASH,
+                )
+                break
+            roll = 4
+            continue
+        if roll == 4:
+            if _parts_has(victim, PartFlag.HEART):
+                message_template = "$n's heart is torn from $s chest."
+                gore_spec = (
+                    OBJ_VNUM_TORN_HEART,
+                    "the heart of %s",
+                    "The torn-out heart of %s is lying here.",
+                    ItemType.FOOD,
+                )
+                break
+            roll = 5
+            continue
+        if roll == 5:
+            if _parts_has(victim, PartFlag.ARMS):
+                message_template = "$n's arm is sliced from $s dead body."
+                gore_spec = (
+                    OBJ_VNUM_SLICED_ARM,
+                    "the arm of %s",
+                    "The sliced-off arm of %s is lying here.",
+                    ItemType.FOOD,
+                )
+                break
+            roll = 6
+            continue
+        if roll == 6:
+            if _parts_has(victim, PartFlag.LEGS):
+                message_template = "$n's leg is sliced from $s dead body."
+                gore_spec = (
+                    OBJ_VNUM_SLICED_LEG,
+                    "the leg of %s",
+                    "The sliced-off leg of %s is lying here.",
+                    ItemType.FOOD,
+                )
+                break
+            roll = 7
+            continue
+        if roll == 7:
+            if _parts_has(victim, PartFlag.BRAINS):
+                message_template = "$n's head is shattered, and $s brains splash all over you."
+                gore_spec = (
+                    OBJ_VNUM_BRAINS,
+                    "the brains of %s",
+                    "The splattered brains of %s are lying here.",
+                    ItemType.FOOD,
+                )
+                break
+        break
+
+    room.broadcast(expand_placeholders(message_template, victim), exclude=victim)
+
+    if gore_spec is not None:
+        _spawn_gore(
+            victim,
+            gore_spec[0],
+            short_template=gore_spec[1],
+            description_template=gore_spec[2],
+            default_item_type=gore_spec[3],
+        )
+
+    _broadcast_neighbor_cry(victim)
+
+
+def _fallback_corpse(vnum: int, *, item_type: ItemType) -> Object:
+    """Return a minimal corpse object when the real prototype is missing."""
+
+    proto = ObjIndex(vnum=vnum, short_descr="a corpse", description="The corpse of someone lies here.")
+    proto.item_type = int(item_type)
+    corpse = Object(instance_id=None, prototype=proto)
+    corpse.item_type = int(item_type)
+    return corpse
+
+
+def _strip_inventory(victim: Character) -> list:
+    """Remove and return all carried and equipped objects from *victim*."""
+
+    items: list = []
+    inventory: Iterable = list(getattr(victim, "inventory", []) or [])
+    for obj in inventory:
+        victim.remove_object(obj)
+        items.append(obj)
+    equipment = getattr(victim, "equipment", {}) or {}
+    for obj in list(equipment.values()):
+        victim.remove_object(obj)
+        items.append(obj)
+    return items
+
+
+def _set_corpse_coins(corpse: Object, gold: int, silver: int) -> None:
+    """Persist coin totals on the corpse and mirror into ``value[0:2]``."""
+
+    corpse.gold = gold
+    corpse.silver = silver
+    values = list(getattr(corpse, "value", []) or [])
+    while len(values) < 2:
+        values.append(0)
+    values[0] = gold
+    values[1] = silver
+    corpse.value = values
+
+
+def make_corpse(victim: Character) -> Object | None:
+    """Create a corpse for *victim* mirroring ROM ``make_corpse`` semantics."""
+
+    room = getattr(victim, "room", None)
+    if room is None:
+        return None
+
+    is_npc = bool(getattr(victim, "is_npc", False))
+    vnum = OBJ_VNUM_CORPSE_NPC if is_npc else OBJ_VNUM_CORPSE_PC
+    corpse = spawn_object(vnum)
+    if corpse is None:
+        corpse = _fallback_corpse(vnum, item_type=ItemType.CORPSE_NPC if is_npc else ItemType.CORPSE_PC)
+    corpse.item_type = int(ItemType.CORPSE_NPC if is_npc else ItemType.CORPSE_PC)
+    corpse.cost = 0
+    corpse.level = int(getattr(victim, "level", 0) or 0)
+    corpse.timer = rng_mm.number_range(3, 6) if is_npc else rng_mm.number_range(25, 40)
+
+    gold = max(0, int(getattr(victim, "gold", 0) or 0))
+    silver = max(0, int(getattr(victim, "silver", 0) or 0))
+    _set_corpse_coins(corpse, gold, silver)
+    victim.gold = max(0, int(getattr(victim, "gold", 0) or 0) - gold)
+    victim.silver = max(0, int(getattr(victim, "silver", 0) or 0) - silver)
+
+    if not is_npc:
+        _clear_player_flag(victim, PlayerFlag.CANLOOT)
+        if not is_clan_member(victim):
+            corpse.owner = getattr(victim, "name", None)
+
+    for obj in _strip_inventory(victim):
+        corpse.contained_items.append(obj)
+        if hasattr(obj, "location"):
+            obj.location = corpse
+
+    room.add_object(corpse)
+    return corpse
+
+
+def _clear_spell_effects(victim: Character) -> None:
+    """Remove all active spell effects restoring stat deltas."""
+
+    if not hasattr(victim, "spell_effects"):
+        return
+    spell_effects = getattr(victim, "spell_effects", {})
+    if not isinstance(spell_effects, dict):
+        return
+    if hasattr(victim, "remove_spell_effect"):
+        for name in list(spell_effects.keys()):
+            victim.remove_spell_effect(name)
+    spell_effects.clear()
+
+
+def _restore_race_affects(victim: Character) -> None:
+    """Reset base affect flags from the character's race entry."""
+
+    race = get_race_by_index(getattr(victim, "race", 0))
+    if race is None:
+        victim.affected_by = 0
+        return
+    victim.affected_by = int(getattr(race, "affect_flags", 0))
+
+
+def _reset_player_armor(victim: Character) -> None:
+    """Restore ROM default armor values (100 per AC slot)."""
+
+    victim.armor = [100, 100, 100, 100]
+
+
+def _move_player_to_death_room(victim: Character) -> None:
+    """Place the player in their clan hall or the global death room."""
+
+    hall_vnum = get_clan_hall_vnum(getattr(victim, "clan", 0))
+    room = get_room(hall_vnum)
+    if room is not None:
+        room.add_character(victim)
+
+
+def raw_kill(victim: Character) -> Object | None:
+    """Handle character death by creating a corpse and removing the victim."""
+
+    from mud.combat.engine import stop_fighting as _stop_fighting
+
+    _stop_fighting(victim, True)
+    death_cry(victim)
+    corpse = make_corpse(victim)
+
+    room = getattr(victim, "room", None)
+    if room is not None:
+        room.remove_character(victim)
+
+    if getattr(victim, "is_npc", False):
+        victim.fighting = None
+        try:
+            character_registry.remove(victim)
+        except ValueError:  # pragma: no cover - defensive guard
+            pass
+        return corpse
+
+    _clear_spell_effects(victim)
+    _restore_race_affects(victim)
+    _reset_player_armor(victim)
+
+    victim.fighting = None
+    victim.position = Position.RESTING
+    victim.hit = max(1, int(getattr(victim, "hit", 0) or 0))
+    victim.mana = max(1, int(getattr(victim, "mana", 0) or 0))
+    victim.move = max(1, int(getattr(victim, "move", 0) or 0))
+    victim.timer = 0
+    _move_player_to_death_room(victim)
+    return corpse
+
+
+__all__ = ["death_cry", "make_corpse", "raw_kill"]

--- a/mud/groups/__init__.py
+++ b/mud/groups/__init__.py
@@ -1,0 +1,5 @@
+"""Group-related helpers and XP distribution utilities."""
+
+from . import xp
+
+__all__ = ["xp"]

--- a/mud/groups/xp.py
+++ b/mud/groups/xp.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import time
+from typing import Iterable
+
+from mud.advancement import gain_exp
+from mud.characters import is_same_group
+from mud.math.c_compat import urange
+from mud.models.character import Character
+from mud.models.constants import ActFlag, ExtraFlag, WearLocation
+from mud.utils import rng_mm
+
+
+def _resolve_level(value: int | None) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def group_members(ch: Character) -> list[Character]:
+    """Return the characters in *ch*'s room that share the same group."""
+
+    room = getattr(ch, "room", None)
+    if room is None:
+        return []
+    people: Iterable[Character] = getattr(room, "people", []) or []
+    return [gch for gch in people if is_same_group(gch, ch)]
+
+
+def _act_has_flag(character: Character, flag: ActFlag) -> bool:
+    try:
+        return bool(int(getattr(character, "act", 0)) & int(flag))
+    except (TypeError, ValueError):
+        return False
+
+
+def _alignment_value(character: Character) -> int:
+    try:
+        return int(getattr(character, "alignment", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _drop_alignment_conflicts(ch: Character) -> None:
+    room = getattr(ch, "room", None)
+    if room is None:
+        return
+
+    equipment = getattr(ch, "equipment", {}) or {}
+    if not equipment:
+        return
+
+    alignment = _alignment_value(ch)
+
+    for obj in list(equipment.values()):
+        try:
+            flags = int(getattr(obj, "extra_flags", 0) or 0)
+        except (TypeError, ValueError):  # pragma: no cover - defensive guard
+            flags = 0
+        if flags == 0:
+            continue
+
+        is_evil = alignment <= -350
+        is_good = alignment >= 350
+        is_neutral = not is_good and not is_evil
+
+        should_drop = False
+        if flags & int(ExtraFlag.ANTI_EVIL) and is_evil:
+            should_drop = True
+        elif flags & int(ExtraFlag.ANTI_GOOD) and is_good:
+            should_drop = True
+        elif flags & int(ExtraFlag.ANTI_NEUTRAL) and is_neutral:
+            should_drop = True
+
+        if not should_drop:
+            continue
+
+        item_name = getattr(obj, "short_descr", None) or getattr(obj, "name", None) or "it"
+        if hasattr(ch, "send_to_char"):
+            ch.send_to_char(f"You are zapped by {item_name}.")
+        room.broadcast(f"{getattr(ch, 'name', 'Someone')} is zapped by {item_name}.", exclude=ch)
+
+        ch.remove_object(obj)
+        obj.wear_loc = int(WearLocation.NONE)
+        room.add_object(obj)
+
+
+def group_gain(ch: Character, victim: Character) -> None:
+    """Distribute experience to *ch*'s group following ROM ``group_gain``."""
+
+    if victim is ch:
+        return
+
+    members = group_members(ch)
+    if not members:
+        members = [ch]
+
+    total_levels = 0
+    for gch in members:
+        level = _resolve_level(getattr(gch, "level", 0))
+        if level <= 0:
+            continue
+        if getattr(gch, "is_npc", False):
+            total_levels += max(1, level // 2)
+        else:
+            total_levels += level
+
+    if total_levels <= 0:
+        total_levels = max(1, _resolve_level(getattr(ch, "level", 0)))
+
+    for gch in members:
+        if getattr(gch, "is_npc", False):
+            continue
+        xp = xp_compute(gch, victim, total_levels)
+        if xp <= 0:
+            _drop_alignment_conflicts(ch)
+            continue
+        gch.send_to_char(f"You receive {xp} experience points.")
+        gain_exp(gch, xp)
+        _drop_alignment_conflicts(ch)
+
+
+def xp_compute(gch: Character, victim: Character, total_levels: int) -> int:
+    """Compute XP awarded for *victim* mirroring ROM ``xp_compute``."""
+
+    gch_level = max(1, _resolve_level(getattr(gch, "level", 0)))
+    victim_level = _resolve_level(getattr(victim, "level", 0))
+    level_range = victim_level - gch_level
+
+    base_table = {
+        -9: 1,
+        -8: 2,
+        -7: 5,
+        -6: 9,
+        -5: 11,
+        -4: 22,
+        -3: 33,
+        -2: 50,
+        -1: 66,
+        0: 83,
+        1: 99,
+        2: 121,
+        3: 143,
+        4: 165,
+    }
+    if level_range in base_table:
+        base_exp = base_table[level_range]
+    elif level_range > 4:
+        base_exp = 160 + 20 * (level_range - 4)
+    else:
+        base_exp = 0
+
+    if base_exp <= 0:
+        return 0
+
+    victim_alignment = _resolve_level(getattr(victim, "alignment", 0))
+    gch_alignment = _resolve_level(getattr(gch, "alignment", 0))
+    align_delta = victim_alignment - gch_alignment
+
+    if not _act_has_flag(victim, ActFlag.NOALIGN):
+        if align_delta > 500:
+            change = (align_delta - 500) * base_exp // 500 * gch_level // max(1, total_levels)
+            change = max(1, change)
+            gch.alignment = max(-1000, gch_alignment - change)
+        elif align_delta < -500:
+            change = (-align_delta - 500) * base_exp // 500 * gch_level // max(1, total_levels)
+            change = max(1, change)
+            gch.alignment = min(1000, gch_alignment + change)
+        else:
+            change = gch_alignment * base_exp // 500 * gch_level // max(1, total_levels)
+            gch.alignment -= change
+
+    if _act_has_flag(victim, ActFlag.NOALIGN):
+        xp = base_exp
+    elif gch_alignment > 500:
+        if victim_alignment < -750:
+            xp = (base_exp * 4) // 3
+        elif victim_alignment < -500:
+            xp = (base_exp * 5) // 4
+        elif victim_alignment > 750:
+            xp = base_exp // 4
+        elif victim_alignment > 500:
+            xp = base_exp // 2
+        elif victim_alignment > 250:
+            xp = (base_exp * 3) // 4
+        else:
+            xp = base_exp
+    elif gch_alignment < -500:
+        if victim_alignment > 750:
+            xp = (base_exp * 5) // 4
+        elif victim_alignment > 500:
+            xp = (base_exp * 11) // 10
+        elif victim_alignment < -750:
+            xp = base_exp // 2
+        elif victim_alignment < -500:
+            xp = (base_exp * 3) // 4
+        elif victim_alignment < -250:
+            xp = (base_exp * 9) // 10
+        else:
+            xp = base_exp
+    elif gch_alignment > 200:
+        if victim_alignment < -500:
+            xp = (base_exp * 6) // 5
+        elif victim_alignment > 750:
+            xp = base_exp // 2
+        elif victim_alignment > 0:
+            xp = (base_exp * 3) // 4
+        else:
+            xp = base_exp
+    elif gch_alignment < -200:
+        if victim_alignment > 500:
+            xp = (base_exp * 6) // 5
+        elif victim_alignment < -750:
+            xp = base_exp // 2
+        elif victim_alignment < 0:
+            xp = (base_exp * 3) // 4
+        else:
+            xp = base_exp
+    else:
+        if abs(victim_alignment) > 500:
+            xp = (base_exp * 4) // 3
+        elif -200 < victim_alignment < 200:
+            xp = base_exp // 2
+        else:
+            xp = base_exp
+
+    if gch_level < 6:
+        xp = 10 * xp // (gch_level + 4)
+    if gch_level > 35:
+        xp = 15 * xp // max(1, gch_level - 25)
+
+    played_seconds = int(getattr(gch, "played", 0) or 0)
+    logon_time = getattr(gch, "logon", None)
+    try:
+        logon_ts = float(logon_time) if logon_time is not None else time.time()
+    except (TypeError, ValueError):
+        logon_ts = time.time()
+    elapsed = max(0, int(time.time() - logon_ts))
+    numerator = 4 * (played_seconds + elapsed)
+    time_per_level = 0
+    if gch_level > 0:
+        time_per_level = numerator // 3600 // gch_level
+    time_per_level = urange(2, time_per_level, 12)
+    if gch_level < 15:
+        time_per_level = max(time_per_level, 15 - gch_level)
+    xp = xp * time_per_level // 12
+
+    low = xp * 3 // 4
+    high = xp * 5 // 4
+    xp = rng_mm.number_range(low, high)
+
+    divisor = max(1, total_levels - 1)
+    xp = xp * gch_level // divisor
+    return max(0, xp)
+
+
+__all__ = ["group_gain", "xp_compute", "group_members"]

--- a/mud/models/clans.py
+++ b/mud/models/clans.py
@@ -1,0 +1,51 @@
+"""ROM clan table metadata for player death/communication flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from mud.models.constants import ROOM_VNUM_ALTAR
+
+
+@dataclass(frozen=True)
+class Clan:
+    """Subset of ROM's ``clan_type`` structure (src/tables.c)."""
+
+    name: str
+    who_name: str
+    hall_vnum: int
+    is_independent: bool
+
+
+CLAN_TABLE: Final[tuple[Clan, ...]] = (
+    Clan("", "", ROOM_VNUM_ALTAR, True),
+    Clan("loner", "[ Loner ] ", ROOM_VNUM_ALTAR, True),
+    Clan("rom", "[  ROM  ] ", ROOM_VNUM_ALTAR, False),
+)
+
+
+def get_clan(clan_id: int) -> Clan:
+    """Return clan metadata by id with clan 0 as the default fallback."""
+
+    try:
+        index = int(clan_id)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        index = 0
+    if index < 0 or index >= len(CLAN_TABLE):
+        index = 0
+    return CLAN_TABLE[index]
+
+
+def get_clan_hall_vnum(clan_id: int) -> int:
+    """Return the hall vnum for *clan_id* falling back to the altar."""
+
+    clan = get_clan(clan_id)
+    hall = getattr(clan, "hall_vnum", ROOM_VNUM_ALTAR)
+    try:
+        return int(hall)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return ROOM_VNUM_ALTAR
+
+
+__all__ = ["Clan", "CLAN_TABLE", "get_clan", "get_clan_hall_vnum"]

--- a/mud/models/constants.py
+++ b/mud/models/constants.py
@@ -18,7 +18,19 @@ class Direction(IntEnum):
 
 # Canonical room/object vnums (merc.h)
 ROOM_VNUM_LIMBO = 2
+ROOM_VNUM_ALTAR = 3054
 ROOM_VNUM_SCHOOL = 3700
+# Utility conjuration targets
+OBJ_VNUM_CORPSE_NPC = 10
+OBJ_VNUM_CORPSE_PC = 11
+OBJ_VNUM_SEVERED_HEAD = 12
+OBJ_VNUM_TORN_HEART = 13
+OBJ_VNUM_SLICED_ARM = 14
+OBJ_VNUM_SLICED_LEG = 15
+OBJ_VNUM_GUTS = 16
+OBJ_VNUM_BRAINS = 17
+OBJ_VNUM_MUSHROOM = 20
+OBJ_VNUM_SPRING = 22
 
 # School equipment (OBJ_VNUM_SCHOOL_*) used during character creation (merc.h)
 OBJ_VNUM_SCHOOL_MACE = 3700
@@ -275,6 +287,9 @@ class ItemType(IntEnum):
     JUKEBOX = 34
 
 
+LIQ_WATER = 0
+
+
 class ActFlag(IntFlag):
     """NPC act flags from ROM merc.h (letters A..Z, aa..dd)."""
 
@@ -419,7 +434,7 @@ class AffectFlag(IntFlag):
     FAERIE_FIRE = 1 << 7
     INFRARED = 1 << 8
     CURSE = 1 << 9
-    UNUSED1 = 1 << 10
+    DETECT_GOOD = 1 << 10
     POISON = 1 << 11
     PROTECT_EVIL = 1 << 12
     PROTECT_GOOD = 1 << 13

--- a/mud/models/object.py
+++ b/mud/models/object.py
@@ -31,6 +31,8 @@ class Object:
     enchanted: bool = False
     item_type: str | None = None
     affected: list[Affect] = field(default_factory=list)
+    _short_descr_override: str | None = field(default=None, repr=False)
+    _description_override: str | None = field(default=None, repr=False)
 
     @property
     def name(self) -> str | None:
@@ -38,4 +40,20 @@ class Object:
 
     @property
     def short_descr(self) -> str | None:
+        if self._short_descr_override is not None:
+            return self._short_descr_override
         return getattr(self.prototype, "short_descr", None)
+
+    @short_descr.setter
+    def short_descr(self, value: str | None) -> None:
+        self._short_descr_override = value
+
+    @property
+    def description(self) -> str | None:
+        if self._description_override is not None:
+            return self._description_override
+        return getattr(self.prototype, "description", None)
+
+    @description.setter
+    def description(self, value: str | None) -> None:
+        self._description_override = value

--- a/mud/models/races.py
+++ b/mud/models/races.py
@@ -503,6 +503,18 @@ _RACES_BY_NAME: Final[dict[str, RaceType]] = {race.name: race for race in RACE_T
 _PC_RACES_BY_NAME: Final[dict[str, PcRaceType]] = {race.name: race for race in PC_RACE_TABLE}
 
 
+def get_race_by_index(index: int) -> RaceType | None:
+    """Return race metadata by numeric index mirroring ROM ``race_table``."""
+
+    try:
+        resolved = int(index)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return None
+    if resolved < 0 or resolved >= len(RACE_TABLE):
+        return None
+    return RACE_TABLE[resolved]
+
+
 def get_race(name: str) -> RaceType | None:
     """Return base race metadata by lowercase name."""
 

--- a/tests/test_combat_death.py
+++ b/tests/test_combat_death.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import pytest
+
+from mud.combat.death import death_cry
+from mud.combat.engine import attack_round
+from mud.groups import xp as xp_module
+from mud.models.character import Character, SpellEffect, character_registry
+from mud.models.constants import (
+    AffectFlag,
+    ExtraFlag,
+    FormFlag,
+    ItemType,
+    PartFlag,
+    PlayerFlag,
+    Position,
+    ROOM_VNUM_ALTAR,
+    Stat,
+    WearLocation,
+    OBJ_VNUM_GUTS,
+)
+from mud.models.obj import ObjIndex
+from mud.models.object import Object
+from mud.utils import rng_mm
+from mud.wiznet import WiznetFlag
+from mud.world import create_test_character, initialize_world
+
+
+@pytest.fixture(autouse=True)
+def reset_characters() -> None:
+    character_registry.clear()
+    yield
+    character_registry.clear()
+
+
+def _ensure_world() -> None:
+    initialize_world("area/area.lst")
+
+
+def _make_victim(name: str, room, *, level: int = 10, hit_points: int = 5, gold: int = 0, silver: int = 0) -> Character:
+    victim = Character(name=name, is_npc=True, level=level)
+    victim.hit = hit_points
+    victim.max_hit = hit_points
+    victim.gold = gold
+    victim.silver = silver
+    room.add_character(victim)
+    return victim
+
+
+def _add_loot(victim: Character, vnum: int, short_descr: str) -> Object:
+    proto = ObjIndex(vnum=vnum, short_descr=short_descr)
+    loot = Object(instance_id=None, prototype=proto)
+    victim.add_object(loot)
+    return loot
+
+
+def test_death_cry_spawns_gore_and_notifies_neighbors(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ensure_world()
+    attacker = create_test_character("Attacker", 3001)
+    room = attacker.room
+    assert room is not None
+
+    neighbor_room = None
+    for exit_data in room.exits:
+        if exit_data and exit_data.to_room is not None:
+            neighbor_room = exit_data.to_room
+            break
+    assert neighbor_room is not None
+
+    observer = create_test_character("Observer", room.vnum)
+    observer.messages = []
+    neighbor = create_test_character("Neighbor", neighbor_room.vnum)
+    neighbor.messages = []
+
+    victim = _make_victim("Victim", room)
+    victim.parts = int(PartFlag.GUTS)
+    victim.form = int(FormFlag.EDIBLE)
+
+    monkeypatch.setattr(rng_mm, "number_bits", lambda bits: 2)
+    monkeypatch.setattr(rng_mm, "number_range", lambda low, high: high)
+
+    existing_objects = {id(obj) for obj in room.contents}
+
+    death_cry(victim)
+
+    new_objects = [obj for obj in room.contents if id(obj) not in existing_objects]
+    gore = next(obj for obj in new_objects if getattr(obj.prototype, "vnum", None) == OBJ_VNUM_GUTS)
+
+    assert gore.timer == 7
+    assert gore.short_descr is not None and "Victim" in gore.short_descr
+    assert any("guts" in message for message in observer.messages)
+    assert any("death cry" in message for message in neighbor.messages)
+
+
+def test_raw_kill_awards_group_xp_and_creates_corpse(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ensure_world()
+    attacker = create_test_character("Attacker", 3001)
+    ally = create_test_character("Ally", 3001)
+    ally.leader = attacker
+    room = attacker.room
+    assert room is not None
+
+    victim = _make_victim("Victim", room, gold=12, silver=3, hit_points=1)
+    loot = _add_loot(victim, 6000, "a battered trinket")
+
+    attacker.level = 10
+    attacker.hitroll = 100
+    attacker.damroll = 12
+    ally.level = 10
+
+    calls: list[tuple[Character, int]] = []
+
+    def fake_xp_compute(gch: Character, vic: Character, total_levels: int) -> int:
+        calls.append((gch, total_levels))
+        return 100
+
+    monkeypatch.setattr(xp_module, "xp_compute", fake_xp_compute)
+    monkeypatch.setattr("mud.utils.rng_mm.number_percent", lambda: 1)
+    monkeypatch.setattr("mud.utils.rng_mm.number_range", lambda low, high: high)
+    monkeypatch.setattr("mud.combat.engine.calculate_weapon_damage", lambda *args, **kwargs: 50)
+
+    monkeypatch.setattr("mud.combat.engine.check_parry", lambda *args, **kwargs: False)
+    monkeypatch.setattr("mud.combat.engine.check_dodge", lambda *args, **kwargs: False)
+    monkeypatch.setattr("mud.combat.engine.check_shield_block", lambda *args, **kwargs: False)
+
+    existing_ids = {id(obj) for obj in room.contents}
+
+    attack_round(attacker, victim)
+
+    assert victim not in room.people
+
+    new_objects = [obj for obj in room.contents if id(obj) not in existing_ids]
+    corpse_candidates = [obj for obj in new_objects if getattr(obj, "item_type", None) == int(ItemType.CORPSE_NPC)]
+    assert len(corpse_candidates) == 1
+    corpse = corpse_candidates[0]
+    assert corpse.gold == 12
+    assert corpse.silver == 3
+    assert loot in corpse.contained_items
+
+    assert attacker.exp == 100
+    assert ally.exp == 100
+    assert any(msg == "You receive 100 experience points." for msg in attacker.messages)
+    assert any(msg == "You receive 100 experience points." for msg in ally.messages)
+    assert len(calls) == 2
+    assert {id(gch) for gch, _ in calls} == {id(attacker), id(ally)}
+
+
+def test_auto_flags_trigger_and_wiznet_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ensure_world()
+    attacker = create_test_character("Attacker", 3001)
+    attacker.act = int(PlayerFlag.AUTOLOOT | PlayerFlag.AUTOGOLD | PlayerFlag.AUTOSAC)
+    attacker.hitroll = 100
+    attacker.damroll = 10
+    room = attacker.room
+    assert room is not None
+
+    victim = _make_victim("Victim", room, gold=7, silver=4, hit_points=1)
+    loot = _add_loot(victim, 6001, "a gleaming idol")
+
+    immortal = Character(name="Immortal", is_npc=False)
+    immortal.is_admin = True
+    immortal.wiznet = int(WiznetFlag.WIZ_ON | WiznetFlag.WIZ_MOBDEATHS)
+    immortal.messages = []
+    character_registry.append(immortal)
+
+    monkeypatch.setattr(xp_module, "xp_compute", lambda *args, **kwargs: 0)
+    monkeypatch.setattr("mud.utils.rng_mm.number_percent", lambda: 1)
+    monkeypatch.setattr("mud.utils.rng_mm.number_range", lambda low, high: high)
+    monkeypatch.setattr("mud.combat.engine.calculate_weapon_damage", lambda *args, **kwargs: 50)
+
+    monkeypatch.setattr("mud.combat.engine.check_parry", lambda *args, **kwargs: False)
+    monkeypatch.setattr("mud.combat.engine.check_dodge", lambda *args, **kwargs: False)
+    monkeypatch.setattr("mud.combat.engine.check_shield_block", lambda *args, **kwargs: False)
+
+    existing_ids = {id(obj) for obj in room.contents}
+
+    attack_round(attacker, victim)
+    assert loot in attacker.inventory
+    assert attacker.gold == 7
+    assert attacker.silver == 4
+
+    new_objects = [obj for obj in room.contents if id(obj) not in existing_ids]
+    corpse = next(obj for obj in new_objects if getattr(obj, "item_type", None) == int(ItemType.CORPSE_NPC))
+    assert corpse.gold == 0
+    assert corpse.silver == 0
+    assert corpse.contained_items == []
+
+    assert any("got toasted by Attacker" in message for message in immortal.messages)
+    assert any("quickly gather" in message for message in attacker.messages)
+
+
+def test_group_gain_zaps_anti_alignment_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ensure_world()
+    attacker = create_test_character("Attacker", 3001)
+    room = attacker.room
+    assert room is not None
+
+    observer = create_test_character("Observer", room.vnum)
+    observer.messages = []
+
+    victim = _make_victim("Victim", room)
+    attacker.level = 10
+    attacker.alignment = -400
+    attacker.messages = []
+
+    proto = ObjIndex(vnum=9000, short_descr="a holy talisman")
+    amulet = Object(instance_id=None, prototype=proto)
+    amulet.extra_flags = int(ExtraFlag.ANTI_EVIL)
+    attacker.equip_object(amulet, "neck")
+
+    monkeypatch.setattr(xp_module, "xp_compute", lambda *args, **kwargs: 25)
+
+    xp_module.group_gain(attacker, victim)
+
+    assert amulet not in attacker.equipment.values()
+    assert amulet in room.contents
+    assert amulet.wear_loc == int(WearLocation.NONE)
+    assert any("You are zapped by" in message for message in attacker.messages)
+    assert any("is zapped by" in message for message in observer.messages)
+
+
+def test_player_kill_clears_pk_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ensure_world()
+    attacker = create_test_character("Attacker", 3001)
+    victim = create_test_character("Victim", 3001)
+    victim.act = int(PlayerFlag.KILLER)
+    victim.hit = 1
+    victim.max_hit = 1
+
+    attacker.hitroll = 100
+    attacker.damroll = 10
+
+    monkeypatch.setattr(xp_module, "xp_compute", lambda *args, **kwargs: 0)
+    monkeypatch.setattr("mud.utils.rng_mm.number_percent", lambda: 1)
+    monkeypatch.setattr("mud.utils.rng_mm.number_range", lambda low, high: high)
+    monkeypatch.setattr("mud.combat.engine.calculate_weapon_damage", lambda *args, **kwargs: 50)
+
+    monkeypatch.setattr("mud.combat.engine.check_parry", lambda *args, **kwargs: False)
+    monkeypatch.setattr("mud.combat.engine.check_dodge", lambda *args, **kwargs: False)
+    monkeypatch.setattr("mud.combat.engine.check_shield_block", lambda *args, **kwargs: False)
+
+    attack_round(attacker, victim)
+    assert victim.act & int(PlayerFlag.KILLER) == 0
+    assert victim.position == Position.RESTING
+    assert victim.hit >= 1
+    assert victim.room is not None
+    assert victim.room.vnum == ROOM_VNUM_ALTAR
+
+
+def test_player_kill_resets_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ensure_world()
+    attacker = create_test_character("Attacker", 3001)
+    victim = create_test_character("Victim", 3001)
+
+    attacker.hitroll = 100
+    attacker.damroll = 10
+
+    victim.race = 2  # elf -> default INFRARED affect
+    victim.hit = 1
+    victim.max_hit = 1
+    victim.mana = 0
+    victim.move = 0
+    victim.clan = 2  # rom clan hall
+    victim.hitroll = 0
+    victim.damroll = 0
+    victim.saving_throw = 0
+    victim.mod_stat = [0, 0, 0, 0, 0]
+    victim.add_affect(AffectFlag.POISON)
+    victim.armor = [25, 25, 25, 25]
+
+    effect = SpellEffect(
+        name="sanctuary",
+        duration=10,
+        level=40,
+        hitroll_mod=5,
+        damroll_mod=3,
+        saving_throw_mod=-2,
+        affect_flag=AffectFlag.SANCTUARY,
+        stat_modifiers={Stat.STR: 2},
+    )
+    victim.apply_spell_effect(effect)
+
+    monkeypatch.setattr(xp_module, "xp_compute", lambda *args, **kwargs: 0)
+    monkeypatch.setattr("mud.utils.rng_mm.number_percent", lambda: 1)
+    monkeypatch.setattr("mud.utils.rng_mm.number_range", lambda low, high: high)
+    monkeypatch.setattr("mud.combat.engine.calculate_weapon_damage", lambda *args, **kwargs: 50)
+
+    monkeypatch.setattr("mud.combat.engine.check_parry", lambda *args, **kwargs: False)
+    monkeypatch.setattr("mud.combat.engine.check_dodge", lambda *args, **kwargs: False)
+    monkeypatch.setattr("mud.combat.engine.check_shield_block", lambda *args, **kwargs: False)
+
+    attack_round(attacker, victim)
+
+    assert victim.spell_effects == {}
+    assert victim.affected_by == int(AffectFlag.INFRARED)
+    assert victim.hitroll == 0
+    assert victim.damroll == 0
+    assert victim.saving_throw == 0
+    assert victim.mod_stat[Stat.STR] == 0
+    assert victim.armor == [100, 100, 100, 100]
+    assert victim.position == Position.RESTING
+    assert victim.hit == 1
+    assert victim.mana == 1
+    assert victim.move == 1
+    assert victim.fighting is None
+    assert victim.room is not None
+    assert victim.room.vnum == ROOM_VNUM_ALTAR

--- a/tests/test_skills_conjuration.py
+++ b/tests/test_skills_conjuration.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from mud.game_loop import SkyState, weather
+from mud.models.character import Character
+from mud.models.constants import (
+    ItemType,
+    LIQ_WATER,
+    OBJ_VNUM_MUSHROOM,
+    OBJ_VNUM_SPRING,
+)
+from mud.models.obj import ObjIndex
+from mud.models.object import Object
+from mud.models.room import Room
+from mud.registry import obj_registry
+from mud.skills.handlers import create_food, create_spring, create_water
+
+
+def _make_room() -> Room:
+    return Room(vnum=1000, name="Glade of Growth")
+
+
+def test_create_food_conjures_mushroom_with_level_values():
+    obj_registry.clear()
+    try:
+        mushroom_proto = ObjIndex(
+            vnum=OBJ_VNUM_MUSHROOM,
+            name="mushroom",
+            short_descr="a mushroom",
+            item_type=int(ItemType.FOOD),
+        )
+        obj_registry[mushroom_proto.vnum] = mushroom_proto
+
+        room = _make_room()
+        caster = Character(name="Aleron", level=12, is_npc=False)
+        observer = Character(name="Witness", is_npc=False)
+        room.add_character(caster)
+        room.add_character(observer)
+
+        conjured = create_food(caster)
+
+        assert conjured is not None
+        assert conjured in room.contents
+        assert conjured.location is room
+        assert conjured.value[0] == 6  # level // 2 using C division semantics
+        assert conjured.value[1] == 12
+        assert caster.messages[-1] == "a mushroom suddenly appears."
+        assert "a mushroom suddenly appears." in observer.messages
+    finally:
+        obj_registry.clear()
+
+
+def test_create_spring_creates_timed_fountain_in_room():
+    obj_registry.clear()
+    try:
+        spring_proto = ObjIndex(
+            vnum=OBJ_VNUM_SPRING,
+            name="spring",
+            short_descr="a spring",
+            item_type=int(ItemType.FOUNTAIN),
+        )
+        obj_registry[spring_proto.vnum] = spring_proto
+
+        room = _make_room()
+        caster = Character(name="Lyssa", level=8, is_npc=False)
+        room.add_character(caster)
+
+        spring = create_spring(caster)
+
+        assert spring is not None
+        assert spring in room.contents
+        assert spring.location is room
+        assert spring.timer == 8
+        assert caster.messages[-1] == "a spring flows from the ground."
+    finally:
+        obj_registry.clear()
+
+
+def test_create_water_fills_drink_container_respecting_capacity():
+    original_sky = weather.sky
+    try:
+        weather.sky = SkyState.RAINING
+
+        room = _make_room()
+        caster = Character(name="Theron", level=10, is_npc=False)
+        room.add_character(caster)
+
+        container_proto = ObjIndex(
+            vnum=12345,
+            name="waterskin",
+            short_descr="a waterskin",
+            item_type=int(ItemType.DRINK_CON),
+        )
+        container = Object(instance_id=None, prototype=container_proto)
+        container.value = [10, 2, LIQ_WATER, 0, 0]
+
+        assert create_water(caster, container) is True
+        assert container.value[1] == 10  # capacity reached in rain (level * 4)
+        assert caster.messages[-1] == "a waterskin is filled."
+    finally:
+        weather.sky = original_sky

--- a/tests/test_skills_damage.py
+++ b/tests/test_skills_damage.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from mud.models.character import Character
+from mud.models.constants import AffectFlag
+from mud.models.room import Room
+from mud.skills import handlers as skill_handlers
+from mud.utils import rng_mm
+
+
+def test_dispel_evil_damages_evil_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    caster = Character(name="Priest", level=30, is_npc=False, alignment=400)
+    victim = Character(name="Shade", level=28, is_npc=False, alignment=-500, hit=200)
+    room = Room(vnum=4100)
+    room.add_character(caster)
+    room.add_character(victim)
+
+    monkeypatch.setattr(skill_handlers, "saves_spell", lambda level, target, dtype: False)
+    monkeypatch.setattr(rng_mm, "dice", lambda number, size: 60)
+
+    damage = skill_handlers.dispel_evil(caster, victim)
+
+    assert damage == 60
+    assert victim.hit == 140
+
+
+def test_demonfire_applies_curse_and_fire_damage(monkeypatch: pytest.MonkeyPatch) -> None:
+    caster = Character(name="Warlock", level=32, is_npc=False, alignment=-600)
+    victim = Character(name="Paladin", level=28, is_npc=False, alignment=450, hit=150)
+    observer = Character(name="Witness", is_npc=False)
+    room = Room(vnum=4200)
+    for ch in (caster, victim, observer):
+        room.add_character(ch)
+
+    dice_values = iter([80])
+    monkeypatch.setattr(rng_mm, "dice", lambda number, size: next(dice_values))
+
+    save_results = iter([False, False])
+
+    def fake_saves(level: int, target: Character, damage_type: int) -> bool:
+        return next(save_results)
+
+    monkeypatch.setattr(skill_handlers, "saves_spell", fake_saves)
+
+    damage = skill_handlers.demonfire(caster, victim)
+
+    assert damage == 80
+    assert victim.hit == 70
+    assert victim.has_affect(AffectFlag.CURSE)
+    assert victim.has_spell_effect("curse")
+    assert caster.alignment == -650
+    assert victim.messages[-1] == "You feel unclean."
+    assert caster.messages[-1] == "Paladin looks very uncomfortable."
+    assert observer.messages[-1] == "Warlock calls forth the demons of Hell upon Paladin!"
+    assert caster.messages[0] == "You conjure forth the demons of hell!"
+    assert victim.messages[0] == "Warlock has assailed you with the demons of Hell!"

--- a/tests/test_skills_detection.py
+++ b/tests/test_skills_detection.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from mud.models.character import Character
+from mud.models.constants import AffectFlag, ItemType
+from mud.models.obj import ObjIndex
+from mud.models.object import Object
+from mud.models.room import Room
+from mud.skills import handlers as skill_handlers
+
+
+def _make_room(vnum: int = 3000) -> Room:
+    room = Room(vnum=vnum, name=f"Room {vnum}")
+    return room
+
+
+def test_detect_invis_applies_affect_and_blocks_duplicates() -> None:
+    caster = Character(name="Seer", level=24, is_npc=False)
+    room = _make_room(3001)
+    room.add_character(caster)
+
+    assert skill_handlers.detect_invis(caster) is True
+    assert caster.has_affect(AffectFlag.DETECT_INVIS)
+    assert caster.has_spell_effect("detect invis")
+    assert caster.messages[-1] == "Your eyes tingle."
+
+    assert skill_handlers.detect_invis(caster) is False
+    assert caster.messages[-1] == "You can already see invisible."
+
+
+def test_detect_evil_applies_affect_and_notifies_caster() -> None:
+    caster = Character(name="Cleric", level=18, is_npc=False)
+    target = Character(name="Scout", level=12, is_npc=False)
+    room = _make_room(3002)
+    room.add_character(caster)
+    room.add_character(target)
+
+    assert skill_handlers.detect_evil(caster, target) is True
+    assert target.has_affect(AffectFlag.DETECT_EVIL)
+    assert target.messages[-1] == "Your eyes tingle."
+    assert caster.messages[-1] == "Ok."
+
+    assert skill_handlers.detect_evil(caster, target) is False
+    assert caster.messages[-1] == "Scout can already detect evil."
+
+
+def test_detect_poison_reports_food_status() -> None:
+    caster = Character(name="Inspector", level=10, is_npc=False)
+    food_proto = ObjIndex(
+        vnum=1010,
+        name="bread",
+        short_descr="a loaf of bread",
+        item_type=int(ItemType.FOOD),
+    )
+    food = Object(instance_id=None, prototype=food_proto)
+    food.value = [5, 0, 0, 1, 0]
+
+    assert skill_handlers.detect_poison(caster, food) is True
+    assert caster.messages[-1] == "You smell poisonous fumes."
+
+    safe_food = Object(instance_id=None, prototype=food_proto)
+    safe_food.value = [5, 0, 0, 0, 0]
+
+    assert skill_handlers.detect_poison(caster, safe_food) is True
+    assert caster.messages[-1] == "It looks delicious."
+
+    weapon_proto = ObjIndex(
+        vnum=2010,
+        name="sword",
+        short_descr="a sword",
+        item_type=int(ItemType.WEAPON),
+    )
+    weapon = Object(instance_id=None, prototype=weapon_proto)
+
+    assert skill_handlers.detect_poison(caster, weapon) is True
+    assert caster.messages[-1] == "It doesn't look poisoned."

--- a/tests/test_skills_healing.py
+++ b/tests/test_skills_healing.py
@@ -1,0 +1,76 @@
+"""Regression tests for ROM cure/heal spell parity."""
+
+from __future__ import annotations
+
+import pytest
+
+from mud.math.c_compat import c_div
+from mud.models.character import Character, SpellEffect
+from mud.models.constants import AffectFlag
+from mud.models.room import Room
+from mud.skills import handlers as skill_handlers
+from mud.utils import rng_mm
+
+
+def test_cure_light_heals_using_rom_dice(monkeypatch: pytest.MonkeyPatch) -> None:
+    caster = Character(name="Cleric", level=24, is_npc=False)
+    target = Character(name="Tank", hit=20, max_hit=40, is_npc=False)
+    room = Room(vnum=3001)
+    for ch in (caster, target):
+        room.add_character(ch)
+
+    monkeypatch.setattr(rng_mm, "dice", lambda number, size: 6)
+
+    healed = skill_handlers.cure_light(caster, target)
+
+    expected = 6 + c_div(caster.level, 3)
+    assert healed == expected
+    assert target.hit == 20 + expected
+    assert target.messages[-1] == "You feel better!"
+    assert caster.messages[-1] == "Ok."
+
+
+def test_cure_disease_and_poison_remove_affects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    caster = Character(name="Healer", level=30, is_npc=False)
+    target = Character(name="Patient", hit=55, max_hit=70, is_npc=False)
+    observer = Character(name="Watcher", is_npc=False)
+    room = Room(vnum=3002)
+    for ch in (caster, target, observer):
+        room.add_character(ch)
+
+    monkeypatch.setattr(rng_mm, "number_percent", lambda: 1)
+
+    plague_effect = SpellEffect(
+        name="plague",
+        duration=10,
+        level=20,
+        affect_flag=AffectFlag.PLAGUE,
+        wear_off_message="Your sores vanish.",
+    )
+    target.apply_spell_effect(plague_effect)
+
+    assert skill_handlers.cure_disease(caster, target) is True
+    assert not target.has_spell_effect("plague")
+    assert not target.has_affect(AffectFlag.PLAGUE)
+    assert "Your sores vanish." in target.messages
+    assert "Patient looks relieved as their sores vanish." in observer.messages
+
+    poison_effect = SpellEffect(
+        name="poison",
+        duration=8,
+        level=18,
+        affect_flag=AffectFlag.POISON,
+        wear_off_message="You feel less sick.",
+    )
+    target.apply_spell_effect(poison_effect)
+
+    assert skill_handlers.cure_poison(caster, target) is True
+    assert not target.has_spell_effect("poison")
+    assert not target.has_affect(AffectFlag.POISON)
+    assert any(
+        message == "A warm feeling runs through your body."
+        for message in target.messages
+    )
+    assert "Patient looks much better." in observer.messages


### PR DESCRIPTION
## Summary
- refresh the PYTHON_PORT_PLAN.md infrastructure markers after a successful pytest collection run
- document a new combat parity task to port NPC kill counter updates when raw_kill executes

## Testing
- pytest --collect-only -q

------
https://chatgpt.com/codex/tasks/task_b_68e40be2a7d083209fd3ec0d440c18de