### PR TITLE
Pyright cleanup across test suite (2.8.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ htmlcov/
 
 # Editor / OS backup files
 *.bak
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.4]
+
+### Changed
+- **Pyright cleanup across test suite.** Eliminated ~30 pre-existing `reportOptionalMemberAccess` / `reportArgumentType` / `reportAttributeAccessIssue` warnings across `tests/test_boards.py`, `tests/test_logging_admin.py`, `tests/test_commands.py`, `tests/test_wiznet.py`, `tests/test_affects.py`, and `tests/test_account_auth.py`. Approach: per-call-site `assert x is not None` guards on `Optional` returns from `find_board(...)`, `from_orm(db_char)`, `load_character(...)`, `Character.pcdata`, etc.; `cast(StreamReader, …)` / `cast(TelnetStream, …)` / `cast(Room, …)` for test doubles; widened `DummyWriter.write` overrides to `bytes | bytearray | memoryview`; initialized possibly-unbound `menu_task: asyncio.Task | None = None`; `# type: ignore[arg-type]` on the two intentional `dam_type=None` cases that exercise edge-case handling. No behavior change; tests still pass at the prior pre-existing-failure baseline.
+
 ## [2.8.3]
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rom24-quickmud-python"
-version = "2.8.3"
+version = "2.8.4"
 description = "A modern Python port of the ROM 2.4b6 MUD engine with full telnet server and JSON world loading"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_account_auth.py
+++ b/tests/test_account_auth.py
@@ -4,7 +4,8 @@ from contextlib import suppress
 from pathlib import Path
 from socket import socket as Socket
 from types import SimpleNamespace
-from typing import Sequence, cast
+from collections.abc import Sequence
+from typing import Protocol, cast
 
 import pytest
 from sqlalchemy import create_engine, inspect, text
@@ -62,6 +63,7 @@ from mud.models.constants import (
 )
 from mud.models.character import (
     Character as RuntimeCharacter,
+    PCData,
     _decode_creation_skills,
     character_registry,
 )
@@ -88,6 +90,19 @@ TELNET_DO = 253
 TELNET_DONT = 254
 TELNET_GA = 249
 TELNET_TELOPT_ECHO = 1
+
+
+class _ConnProto(Protocol):
+    """Structural subset of TelnetStream used by test doubles.
+
+    Functions like _run_character_login, _run_character_creation_flow, and
+    _select_character accept TelnetStream, but several tests pass lightweight
+    SimpleNamespace / FakeStream objects that satisfy the same structural
+    contract.  Casting to TelnetStream (via cast()) silences the arg-type errors
+    without changing runtime behaviour.
+    """
+
+    peer_host: str | None
 
 
 @pytest.fixture(autouse=True)
@@ -136,7 +151,7 @@ class _MemoryTransport(asyncio.Transport):
         self.buffer = bytearray()
         self._closing = False
 
-    def write(self, data: bytes) -> None:
+    def write(self, data: bytes | bytearray | memoryview) -> None:  # type: ignore[override]
         self.buffer.extend(data)
 
     def is_closing(self) -> bool:
@@ -560,7 +575,7 @@ def test_creation_race_help(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(net_connection, "do_help", fake_do_help)
 
     async def run() -> None:
-        race = await net_connection._prompt_for_race(object(), helper)
+        race = await net_connection._prompt_for_race(cast(net_connection.TelnetStream, object()), helper)  # test double for TelnetStream
         assert race is not None
         assert race.name == "human"
 
@@ -712,6 +727,7 @@ def test_customization_menu_repeats_menu_choice_help(monkeypatch: pytest.MonkeyP
 
         monkeypatch.setattr(net_connection, "do_help", fake_do_help)
 
+        menu_task: asyncio.Task | None = None
         try:
             menu_task = asyncio.create_task(net_connection._run_customization_menu(conn, selection))
             await asyncio.sleep(0)
@@ -731,9 +747,10 @@ def test_customization_menu_repeats_menu_choice_help(monkeypatch: pytest.MonkeyP
             help_output = transport.buffer.decode(errors="ignore")
             assert "Menu choice text" in help_output
         finally:
-            menu_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await menu_task
+            if menu_task is not None:
+                menu_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await menu_task
             transport.close()
             protocol.connection_lost(None)
 
@@ -747,7 +764,7 @@ def test_customization_requires_forty_creation_points():
             self.buffer = bytearray()
             self._closing = False
 
-        def write(self, data: bytes) -> None:
+        def write(self, data: bytes | bytearray | memoryview) -> None:  # type: ignore[override]
             self.buffer.extend(data)
 
         def is_closing(self) -> bool:
@@ -815,6 +832,7 @@ def test_customization_requires_forty_creation_points():
         assert "Creation points: 44" in final_output
         assert "Experience per level: 1200" in final_output
         assert result is selection
+        assert result is not None
         assert result.creation_points == 44
         assert result.minimum_creation_points() == 40
 
@@ -831,7 +849,7 @@ def test_customization_menu_supports_drop_and_info():
             self.buffer = bytearray()
             self._closing = False
 
-        def write(self, data: bytes) -> None:
+        def write(self, data: bytes | bytearray | memoryview) -> None:  # type: ignore[override]
             self.buffer.extend(data)
 
         def is_closing(self) -> bool:
@@ -859,7 +877,9 @@ def test_customization_menu_supports_drop_and_info():
         group_name, group_cost = next(
             (name, cost) for name, cost in selection.available_groups() if name.lower() == "creation"
         )
-        group_members = get_group(group_name).skills
+        _group = get_group(group_name)
+        assert _group is not None, f"group {group_name!r} not found"
+        group_members = _group.skills
 
         menu_task = asyncio.create_task(net_connection._run_customization_menu(conn, selection))
         await asyncio.sleep(0)
@@ -1613,7 +1633,7 @@ def test_character_login_rejects_wrong_password_once(monkeypatch):
     bad_result = LoginResult(account=None, failure=LoginFailureReason.BAD_CREDENTIALS, was_reconnect=False)
     monkeypatch.setattr(net_connection, "login_with_host", lambda *a, **kw: bad_result, raising=False)
 
-    result = asyncio.run(_run_character_login(FakeStream(), None))
+    result = asyncio.run(_run_character_login(cast(net_connection.TelnetStream, FakeStream()), None))  # test double for TelnetStream
 
     assert result is None
     assert prompts.count("Name: ") == 1
@@ -1627,7 +1647,7 @@ def test_password_echo_suppressed():
             self.writes: list[bytes] = []
             self.closed = False
 
-        def write(self, data: bytes) -> None:
+        def write(self, data: bytes | bytearray | memoryview) -> None:  # type: ignore[override]
             self.writes.append(bytes(data))
 
         async def drain(self) -> None:  # pragma: no cover - behavioural stub
@@ -1642,7 +1662,7 @@ def test_password_echo_suppressed():
     async def run() -> None:
         reader = asyncio.StreamReader()
         writer = DummyWriter()
-        conn = net_connection.TelnetStream(reader, writer)
+        conn = net_connection.TelnetStream(reader, cast(asyncio.StreamWriter, writer))  # test double for StreamWriter
 
         reader.feed_data(b"secret\r\n")
         reader.feed_eof()
@@ -1791,7 +1811,7 @@ def test_new_player_triggers_wiznet_newbie_alert(monkeypatch):
             monkeypatch.setattr(net_connection, "_prompt_for_weapon", fake_prompt_for_weapon)
             monkeypatch.setattr(net_connection, "_send_line", fake_send_line)
 
-            dummy_conn = SimpleNamespace(peer_host="academy.example")
+            dummy_conn = cast(net_connection.TelnetStream, SimpleNamespace(peer_host="academy.example"))  # test double for TelnetStream
             dummy_account = SimpleNamespace(id=1)
 
             result = await net_connection._run_character_creation_flow(dummy_conn, dummy_account, "Nova")
@@ -1839,7 +1859,7 @@ def test_newbie_banned_blocks_character_creation(monkeypatch):
     monkeypatch.setattr(net_connection, "create_character", fake_create_character)
 
     async def run_test() -> bool:
-        dummy_conn = SimpleNamespace(peer_host="blocked.example")
+        dummy_conn = cast(net_connection.TelnetStream, SimpleNamespace(peer_host="blocked.example"))  # test double for TelnetStream
         dummy_account = SimpleNamespace(id=1)
         return await net_connection._run_character_creation_flow(
             dummy_conn,
@@ -1872,7 +1892,7 @@ def test_select_character_blocks_newbie_creation_when_banned(monkeypatch):
 
     async def run_test():
         net_connection.SESSIONS.clear()
-        dummy_conn = SimpleNamespace()
+        dummy_conn = cast(net_connection.TelnetStream, SimpleNamespace())  # test double for TelnetStream
         account = SimpleNamespace()
         result = await net_connection._select_character(
             dummy_conn,
@@ -2383,7 +2403,7 @@ def test_reconnect_announces_note_reminder(monkeypatch):
         sex=Sex.MALE,
     )
     reconnecting.connection = SimpleNamespace(peer_host="midgaard.example")
-    reconnecting.pcdata = SimpleNamespace(in_progress="draft")
+    reconnecting.pcdata = cast(PCData, SimpleNamespace(in_progress="draft"))  # test double for PCData
 
     link_listener = RuntimeCharacter(
         name="LinkImm",
@@ -2507,7 +2527,7 @@ def test_character_selection_filters_permit_hosts():
         assert permit_login.account is not None
         account_q = permit_login.account
 
-        conn_q = SimpleNamespace(host="127.0.0.1")
+        conn_q = cast(net_connection.TelnetStream, SimpleNamespace(host="127.0.0.1"))  # test double for TelnetStream
         result = await net_connection._select_character(
             conn_q, account_q, "quorblix", permit_banned=True
         )

--- a/tests/test_affects.py
+++ b/tests/test_affects.py
@@ -178,7 +178,7 @@ def test_check_immune_handles_unknown_damage_type():
     victim.imm_flags = DefenseBit.MAGIC
     assert _check_immune(victim, 999) == 1
 
-    assert _check_immune(victim, None) == -1
+    assert _check_immune(victim, None) == -1  # type: ignore[arg-type]  # exercises None-handling edge case
 
 
 def test_saves_spell_handles_unknown_damage_type(monkeypatch):
@@ -187,7 +187,7 @@ def test_saves_spell_handles_unknown_damage_type(monkeypatch):
     victim.imm_flags = DefenseBit.MAGIC
 
     assert saves_spell(10, victim, 999) is True
-    assert saves_spell(10, victim, None) is True
+    assert saves_spell(10, victim, None) is True  # type: ignore[arg-type]  # exercises None-handling edge case
 
 
 def test_saves_dispel_matches_rom(monkeypatch):
@@ -454,7 +454,9 @@ def test_affect_persistence():
     session = SessionLocal()
     try:
         db_char = session.query(DBCharacter).filter_by(name="Flags").first()
+        assert db_char is not None
         ch = from_orm(db_char)
+        assert ch is not None
     finally:
         session.close()
 

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -34,6 +34,7 @@ def test_note_persistence(tmp_path):
         initialize_world("area/area.lst")
         character_registry.clear()
         char = create_test_character("Author", 3001)
+        assert char.pcdata is not None
         char.level = 5
         output = process_command(char, "note post Hello|This is a test")
         assert "posted" in output.lower()
@@ -72,6 +73,7 @@ def test_note_list_filters_visible_range(tmp_path):
         notes.save_board(board)
 
         char = create_test_character("Reader", 3001)
+        assert char.pcdata is not None
         char.level = 5
 
         full_list = process_command(char, "note list")
@@ -117,6 +119,7 @@ def test_note_list_hides_private_notes(tmp_path):
         notes.save_board(board)
 
         char = create_test_character("Reader", 3001)
+        assert char.pcdata is not None
         char.level = 5
 
         output = process_command(char, "note list")
@@ -157,6 +160,7 @@ def test_initialize_world_loads_boards_from_disk(tmp_path):
         assert loaded_board.description == "General discussion"
 
         char = create_test_character("Reader", 3001)
+        assert char.pcdata is not None
         char.level = 5
         board_output = process_command(char, "board")
         assert "general" in board_output.lower()
@@ -193,6 +197,7 @@ def test_board_switching_and_unread_counts(tmp_path):
         notes.save_board(general)
 
         char = create_test_character("Reader", 3001)
+        assert char.pcdata is not None
         char.level = 10
         board_output = process_command(char, "board")
         assert "general" in board_output.lower()
@@ -235,6 +240,7 @@ def test_board_listing_uses_rom_colors(tmp_path):
         general.post("Immortal", "Welcome", "Read the rules")
 
         char = create_test_character("Reader", 3001)
+        assert char.pcdata is not None
         char.level = 5
 
         output = process_command(char, "board")
@@ -290,7 +296,9 @@ def test_board_switching_persists_last_note(tmp_path):
         session = SessionLocal()
         try:
             db_char = session.query(DBCharacter).filter_by(name="Archivist").first()
+            assert db_char is not None
             char = from_orm(db_char)
+            assert char.pcdata is not None
         finally:
             session.close()
         char.level = 50
@@ -314,6 +322,7 @@ def test_board_switching_persists_last_note(tmp_path):
 
         loaded = load_character("Archivist")
         assert loaded is not None
+        assert loaded.pcdata is not None
         assert loaded.pcdata.board_name == ideas.storage_key()
         board_listing = process_command(loaded, "board")
         assert "ideas" in board_listing.lower()
@@ -344,6 +353,7 @@ def test_board_listing_retains_current_board_without_access(tmp_path):
         notes.save_board(personal)
 
         char = create_test_character("Scout", 3001)
+        assert char.pcdata is not None
         char.level = 30
         char.trust = 30
         char.pcdata.board_name = personal.storage_key()
@@ -371,6 +381,7 @@ def test_board_listing_falls_back_to_default_when_missing(tmp_path):
         notes.save_board(general)
 
         char = create_test_character("Traveler", 3001)
+        assert char.pcdata is not None
         char.level = 10
         char.pcdata.board_name = "ghost"
 
@@ -401,6 +412,7 @@ def test_note_write_pipeline_enforces_defaults(tmp_path):
         notes.save_board(board)
 
         char = create_test_character("Scribe", 3001)
+        assert char.pcdata is not None
         char.level = 60
         char.trust = 60
 
@@ -411,6 +423,7 @@ def test_note_write_pipeline_enforces_defaults(tmp_path):
         assert "must include imm" in start_output.lower()
 
         set_to = process_command(char, "note to mortal")
+        assert char.pcdata.in_progress is not None
         assert "mortal imm" in char.pcdata.in_progress.to.lower()
         assert "mortal imm" in set_to.lower()
 
@@ -448,6 +461,7 @@ def test_note_expire_allows_immortal_override(tmp_path, monkeypatch: pytest.Monk
         notes.save_board(board)
 
         char = create_test_character("Sage", 3001)
+        assert char.pcdata is not None
         char.level = MAX_LEVEL
         char.trust = MAX_LEVEL
 
@@ -491,6 +505,7 @@ def test_note_expire_rejects_mortals(tmp_path, monkeypatch: pytest.MonkeyPatch):
         notes.save_board(board)
 
         char = create_test_character("Author", 3001)
+        assert char.pcdata is not None
         char.level = 20
         char.trust = 20
 
@@ -575,6 +590,7 @@ def test_note_remove_rejects_notes_not_addressed_to_character(tmp_path):
         notes.save_board(board)
 
         mortal = create_test_character("Adventurer", 3001)
+        assert mortal.pcdata is not None
         mortal.level = 30
         mortal.trust = 30
 
@@ -614,6 +630,7 @@ def test_note_read_respects_visibility(tmp_path):
         notes.save_board(board)
 
         mortal = create_test_character("Adventurer", 3001)
+        assert mortal.pcdata is not None
         mortal.level = 30
         mortal.trust = 30
 
@@ -666,6 +683,7 @@ def test_note_read_includes_header_metadata(tmp_path):
         assert "Greetings, adventurers!" in explicit
 
         auto_reader = create_test_character("Historian", 3001)
+        assert auto_reader.pcdata is not None
         auto_reader.level = 60
         auto_reader.trust = 60
 
@@ -699,6 +717,7 @@ def test_note_catchup_marks_all_read(tmp_path):
         notes.save_board(board)
 
         char = create_test_character("Archivist", 3001)
+        assert char.pcdata is not None
         char.level = 45
         char.trust = 45
 
@@ -735,6 +754,7 @@ def test_note_read_defaults_to_next_unread(tmp_path):
         notes.save_board(board)
 
         char = create_test_character("Reader", 3001)
+        assert char.pcdata is not None
         char.level = 50
         char.trust = 50
 
@@ -786,6 +806,7 @@ def test_note_read_advances_to_next_board_when_exhausted(tmp_path):
         notes.save_board(ideas)
 
         char = create_test_character("Seeker", 3001)
+        assert char.pcdata is not None
         char.level = 50
         char.trust = 50
         char.pcdata.last_notes[general.storage_key()] = general_note.timestamp
@@ -826,6 +847,7 @@ def test_board_change_blocked_during_note_draft(tmp_path):
         notes.save_board(ideas)
 
         char = create_test_character("Scribe", 3001)
+        assert char.pcdata is not None
         char.level = 60
         char.trust = 60
 

--- a/tests/test_logging_admin.py
+++ b/tests/test_logging_admin.py
@@ -1,8 +1,12 @@
 import asyncio
+from asyncio import StreamReader
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from types import SimpleNamespace
+
+from mud.models.room import Room
+from mud.net.connection import TelnetStream
 
 from mud.commands import process_command
 import mud.logging as mud_logging
@@ -26,8 +30,9 @@ def setup_module(module):
 
 def teardown_function(function):
     for character in list(character_registry):
-        if getattr(character, "room", None):
-            character.room.remove_character(character)
+        room = getattr(character, "room", None)
+        if room is not None:
+            room.remove_character(character)
     character_registry.clear()
     SESSIONS.clear()
     set_log_all(False)
@@ -150,7 +155,9 @@ def test_log_flag_persists_in_save(monkeypatch, tmp_path):
     session = SessionLocal()
     try:
         db_char = session.query(DBCharacter).filter_by(name="Player").first()
+        assert db_char is not None
         player = from_orm(db_char)
+        assert player is not None
     finally:
         session.close()
 
@@ -241,15 +248,16 @@ def test_forced_disconnect_logs_closing_link(monkeypatch):
     dummy_conn = DummyConnection()
     player.connection = dummy_conn
     broadcasted: list[str] = []
-    player.room = SimpleNamespace(
+    player.room = cast(Room, SimpleNamespace(
         broadcast=lambda message, exclude=None: broadcasted.append(message),
         remove_character=lambda character: None,
-    )
+    ))
+    assert player.name is not None
     session = Session(
         name=player.name,
         character=player,
-        reader=SimpleNamespace(),
-        connection=dummy_conn,
+        reader=cast(StreamReader, SimpleNamespace()),
+        connection=cast(TelnetStream, dummy_conn),
         account_name="account",
         ansi_enabled=True,
     )


### PR DESCRIPTION
## Summary

Eliminates ~30 pre-existing pyright errors across 6 test files. Pure type-cleanup; no behavior changes.

- **Optional guards.** `assert x is not None` after `find_board(...)`, `from_orm(db_char)`, `load_character(...)`, `Character.pcdata`, `Session.query(...).first()`, `get_group(...)` etc.
- **Type casts for test doubles.** `cast(Room, SimpleNamespace(...))`, `cast(StreamReader, SimpleNamespace())`, `cast(TelnetStream, DummyConnection())`, `cast(asyncio.StreamWriter, DummyWriter())`, `cast(net_connection.TelnetStream, object())` where lightweight test doubles satisfy structural subset of the production type.
- **Possibly-unbound init.** `menu_task: asyncio.Task | None = None` initialized before the try block; guarded before await.
- **Override widening.** `DummyWriter.write` and `_MemoryTransport.write` signatures widened to `bytes | bytearray | memoryview` (with `# type: ignore[override]`) to match `WriteTransport.write`.
- **Intentional `None` args preserved.** `tests/test_affects.py` lines 181/190 deliberately pass `dam_type=None` to exercise edge-case handling — kept with `# type: ignore[arg-type]` and inline comment.
- **`.claude/worktrees/`** added to `.gitignore` so the subagent scratch dirs no longer show as untracked.
- **`mud/persistence.py` references in module docstrings** are historical and intentionally untouched.

## Test plan

- [x] `pytest tests/test_boards.py tests/test_logging_admin.py tests/test_commands.py tests/test_wiznet.py tests/test_affects.py tests/test_account_auth.py -q` — **154 passed, 15 failed**.
- [x] Failure breakdown matches the pre-existing baseline documented in `docs/sessions/SESSION_STATUS.md` "Open Follow-ups": `test_account_auth × 2` dispatcher, `test_commands × ~5` "Huh?", `test_logging_admin × ~8` "Huh?". Verified via `git stash` baseline that `test_log_toggles_per_character_logging` fails identically without this PR's changes.
- [x] No new failures introduced. The asserts/casts are runtime no-ops against existing test inputs (e.g. `create_test_character` always sets `pcdata`, so `assert char.pcdata is not None` cannot trip in practice).
- [ ] Full suite — pre-existing ~30 failures and ~12 min runtime predate this work; not re-verified end-to-end here.

## Notes

- Pyright still flags ~12 informational `"X" is not accessed` warnings inside test files (unused fixture parameters, dummy-method args). Left in place — those are not errors and silencing them would touch lines well beyond this PR's scope.
- Two `reportAttributeAccessIssue` errors in `mud/db/serializers.py` (`race_table` / `clan_table` import; `MobInstance.sex/.position/.armor` mismatches) survive — they were carried over verbatim from the deleted `mud/persistence.py` and are not introduced by this PR. Out of scope; should be addressed when those serializers are next touched substantively.